### PR TITLE
[DesignSystem] 컬러, 커스텀 폰트 추가

### DIFF
--- a/Waving-iOS.xcodeproj/project.pbxproj
+++ b/Waving-iOS.xcodeproj/project.pbxproj
@@ -8,6 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		A82EC6632A2634B500DABF26 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82EC6622A2634B500DABF26 /* Colors.swift */; };
+		A82EC6712A26380A00DABF26 /* Pretendard-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A82EC6682A26380A00DABF26 /* Pretendard-Medium.ttf */; };
+		A82EC6732A26380A00DABF26 /* Pretendard-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A82EC66A2A26380A00DABF26 /* Pretendard-Regular.ttf */; };
+		A82EC6752A26380A00DABF26 /* Pretendard-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A82EC66C2A26380A00DABF26 /* Pretendard-Bold.ttf */; };
+		A82EC67A2A263D1800DABF26 /* FontManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82EC6792A263D1800DABF26 /* FontManager.swift */; };
 		A8E0C0B92A23641F00C8696E /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E0C0B82A23641F00C8696E /* Log.swift */; };
 		A8E0C0EA2A23659400C8696E /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = A8E0C0E92A23659400C8696E /* RxCocoa */; };
 		A8E0C0EC2A23659400C8696E /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = A8E0C0EB2A23659400C8696E /* RxRelay */; };
@@ -50,6 +54,10 @@
 
 /* Begin PBXFileReference section */
 		A82EC6622A2634B500DABF26 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
+		A82EC6682A26380A00DABF26 /* Pretendard-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Medium.ttf"; path = "../../../../../../../../Desktop/Pretendard-1.3.6/public/static/alternative/Pretendard-Medium.ttf"; sourceTree = "<group>"; };
+		A82EC66A2A26380A00DABF26 /* Pretendard-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Regular.ttf"; path = "../../../../../../../../Desktop/Pretendard-1.3.6/public/static/alternative/Pretendard-Regular.ttf"; sourceTree = "<group>"; };
+		A82EC66C2A26380A00DABF26 /* Pretendard-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Bold.ttf"; path = "../../../../../../../../Desktop/Pretendard-1.3.6/public/static/alternative/Pretendard-Bold.ttf"; sourceTree = "<group>"; };
+		A82EC6792A263D1800DABF26 /* FontManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontManager.swift; sourceTree = "<group>"; };
 		A8E0C0B82A23641F00C8696E /* Log.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		A8E0C10E2A23685C00C8696E /* SnapKitInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapKitInterface.swift; sourceTree = "<group>"; };
 		CE0412AA2A23552200C790F3 /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
@@ -122,8 +130,20 @@
 		A82EC6612A26344200DABF26 /* Font */ = {
 			isa = PBXGroup;
 			children = (
+				A82EC6642A2637F200DABF26 /* Pretendard */,
+				A82EC6792A263D1800DABF26 /* FontManager.swift */,
 			);
 			path = Font;
+			sourceTree = "<group>";
+		};
+		A82EC6642A2637F200DABF26 /* Pretendard */ = {
+			isa = PBXGroup;
+			children = (
+				A82EC66C2A26380A00DABF26 /* Pretendard-Bold.ttf */,
+				A82EC6682A26380A00DABF26 /* Pretendard-Medium.ttf */,
+				A82EC66A2A26380A00DABF26 /* Pretendard-Regular.ttf */,
+			);
+			path = Pretendard;
 			sourceTree = "<group>";
 		};
 		A8E0C0B22A23636100C8696E /* Application */ = {
@@ -360,6 +380,9 @@
 			files = (
 				CEE3E7862A17A93300BC1464 /* LaunchScreen.storyboard in Resources */,
 				CEE3E7832A17A93300BC1464 /* Assets.xcassets in Resources */,
+				A82EC6732A26380A00DABF26 /* Pretendard-Regular.ttf in Resources */,
+				A82EC6712A26380A00DABF26 /* Pretendard-Medium.ttf in Resources */,
+				A82EC6752A26380A00DABF26 /* Pretendard-Bold.ttf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -394,6 +417,7 @@
 				CE0412B12A23640500C790F3 /* HomeViewController.swift in Sources */,
 				CE0412B52A23643400C790F3 /* SettingViewController.swift in Sources */,
 				CE0412AB2A23552200C790F3 /* MainTabBarController.swift in Sources */,
+				A82EC67A2A263D1800DABF26 /* FontManager.swift in Sources */,
 				CE0412B32A23642200C790F3 /* FriendsViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Waving-iOS.xcodeproj/project.pbxproj
+++ b/Waving-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A82EC6632A2634B500DABF26 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82EC6622A2634B500DABF26 /* Colors.swift */; };
 		A8E0C0B92A23641F00C8696E /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E0C0B82A23641F00C8696E /* Log.swift */; };
 		A8E0C0EA2A23659400C8696E /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = A8E0C0E92A23659400C8696E /* RxCocoa */; };
 		A8E0C0EC2A23659400C8696E /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = A8E0C0EB2A23659400C8696E /* RxRelay */; };
@@ -48,6 +49,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A82EC6622A2634B500DABF26 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		A8E0C0B82A23641F00C8696E /* Log.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		A8E0C10E2A23685C00C8696E /* SnapKitInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapKitInterface.swift; sourceTree = "<group>"; };
 		CE0412AA2A23552200C790F3 /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
@@ -100,6 +102,30 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		A82EC65F2A26340B00DABF26 /* DesignSystem */ = {
+			isa = PBXGroup;
+			children = (
+				A82EC6612A26344200DABF26 /* Font */,
+				A82EC6602A26343A00DABF26 /* Color */,
+			);
+			path = DesignSystem;
+			sourceTree = "<group>";
+		};
+		A82EC6602A26343A00DABF26 /* Color */ = {
+			isa = PBXGroup;
+			children = (
+				A82EC6622A2634B500DABF26 /* Colors.swift */,
+			);
+			path = Color;
+			sourceTree = "<group>";
+		};
+		A82EC6612A26344200DABF26 /* Font */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Font;
+			sourceTree = "<group>";
+		};
 		A8E0C0B22A23636100C8696E /* Application */ = {
 			isa = PBXGroup;
 			children = (
@@ -189,6 +215,7 @@
 				A8E0C10B2A23678800C8696E /* Domain */,
 				A8E0C0B52A23639400C8696E /* Presentation */,
 				A8E0C0B72A23641000C8696E /* Support */,
+				A82EC65F2A26340B00DABF26 /* DesignSystem */,
 				A8E0C0B62A2363A200C8696E /* Resources */,
 				A8E0C0B22A23636100C8696E /* Application */,
 				CEE3E7872A17A93300BC1464 /* Info.plist */,
@@ -358,6 +385,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CE0412AE2A2359CF00C790F3 /* MainTabBarViewModel.swift in Sources */,
+				A82EC6632A2634B500DABF26 /* Colors.swift in Sources */,
 				CEE3E77E2A17A93200BC1464 /* ViewController.swift in Sources */,
 				CEE3E77A2A17A93200BC1464 /* AppDelegate.swift in Sources */,
 				A8E0C10F2A23685C00C8696E /* SnapKitInterface.swift in Sources */,

--- a/Waving-iOS.xcodeproj/project.pbxproj
+++ b/Waving-iOS.xcodeproj/project.pbxproj
@@ -8,10 +8,10 @@
 
 /* Begin PBXBuildFile section */
 		A82EC6632A2634B500DABF26 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82EC6622A2634B500DABF26 /* Colors.swift */; };
-		A82EC6712A26380A00DABF26 /* Pretendard-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A82EC6682A26380A00DABF26 /* Pretendard-Medium.ttf */; };
-		A82EC6732A26380A00DABF26 /* Pretendard-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A82EC66A2A26380A00DABF26 /* Pretendard-Regular.ttf */; };
-		A82EC6752A26380A00DABF26 /* Pretendard-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A82EC66C2A26380A00DABF26 /* Pretendard-Bold.ttf */; };
 		A82EC67A2A263D1800DABF26 /* FontManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A82EC6792A263D1800DABF26 /* FontManager.swift */; };
+		A88B18C02A26EEC50027B5FD /* Pretendard-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A88B18BF2A26EEC50027B5FD /* Pretendard-Bold.ttf */; };
+		A88B18C22A26EECF0027B5FD /* Pretendard-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A88B18C12A26EECF0027B5FD /* Pretendard-Medium.ttf */; };
+		A88B18C42A26EEDA0027B5FD /* Pretendard-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A88B18C32A26EEDA0027B5FD /* Pretendard-Regular.ttf */; };
 		A8E0C0B92A23641F00C8696E /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E0C0B82A23641F00C8696E /* Log.swift */; };
 		A8E0C0EA2A23659400C8696E /* RxCocoa in Frameworks */ = {isa = PBXBuildFile; productRef = A8E0C0E92A23659400C8696E /* RxCocoa */; };
 		A8E0C0EC2A23659400C8696E /* RxRelay in Frameworks */ = {isa = PBXBuildFile; productRef = A8E0C0EB2A23659400C8696E /* RxRelay */; };
@@ -54,10 +54,10 @@
 
 /* Begin PBXFileReference section */
 		A82EC6622A2634B500DABF26 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
-		A82EC6682A26380A00DABF26 /* Pretendard-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Medium.ttf"; path = "../../../../../../../../Desktop/Pretendard-1.3.6/public/static/alternative/Pretendard-Medium.ttf"; sourceTree = "<group>"; };
-		A82EC66A2A26380A00DABF26 /* Pretendard-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Regular.ttf"; path = "../../../../../../../../Desktop/Pretendard-1.3.6/public/static/alternative/Pretendard-Regular.ttf"; sourceTree = "<group>"; };
-		A82EC66C2A26380A00DABF26 /* Pretendard-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Bold.ttf"; path = "../../../../../../../../Desktop/Pretendard-1.3.6/public/static/alternative/Pretendard-Bold.ttf"; sourceTree = "<group>"; };
 		A82EC6792A263D1800DABF26 /* FontManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontManager.swift; sourceTree = "<group>"; };
+		A88B18BF2A26EEC50027B5FD /* Pretendard-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Bold.ttf"; path = "../../../../../../../../Downloads/Pretendard-1.3.6/public/static/alternative/Pretendard-Bold.ttf"; sourceTree = "<group>"; };
+		A88B18C12A26EECF0027B5FD /* Pretendard-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Medium.ttf"; path = "../../../../../../../../Downloads/Pretendard-1.3.6/public/static/alternative/Pretendard-Medium.ttf"; sourceTree = "<group>"; };
+		A88B18C32A26EEDA0027B5FD /* Pretendard-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; name = "Pretendard-Regular.ttf"; path = "../../../../../../../../Downloads/Pretendard-1.3.6/public/static/alternative/Pretendard-Regular.ttf"; sourceTree = "<group>"; };
 		A8E0C0B82A23641F00C8696E /* Log.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		A8E0C10E2A23685C00C8696E /* SnapKitInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapKitInterface.swift; sourceTree = "<group>"; };
 		CE0412AA2A23552200C790F3 /* MainTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarController.swift; sourceTree = "<group>"; };
@@ -113,6 +113,7 @@
 		A82EC65F2A26340B00DABF26 /* DesignSystem */ = {
 			isa = PBXGroup;
 			children = (
+				A82EC67B2A26407000DABF26 /* Components */,
 				A82EC6612A26344200DABF26 /* Font */,
 				A82EC6602A26343A00DABF26 /* Color */,
 			);
@@ -139,11 +140,26 @@
 		A82EC6642A2637F200DABF26 /* Pretendard */ = {
 			isa = PBXGroup;
 			children = (
-				A82EC66C2A26380A00DABF26 /* Pretendard-Bold.ttf */,
-				A82EC6682A26380A00DABF26 /* Pretendard-Medium.ttf */,
-				A82EC66A2A26380A00DABF26 /* Pretendard-Regular.ttf */,
+				A88B18C12A26EECF0027B5FD /* Pretendard-Medium.ttf */,
+				A88B18C32A26EEDA0027B5FD /* Pretendard-Regular.ttf */,
+				A88B18BF2A26EEC50027B5FD /* Pretendard-Bold.ttf */,
 			);
 			path = Pretendard;
+			sourceTree = "<group>";
+		};
+		A82EC67B2A26407000DABF26 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				A82EC67C2A26407E00DABF26 /* NavigationBar */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		A82EC67C2A26407E00DABF26 /* NavigationBar */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = NavigationBar;
 			sourceTree = "<group>";
 		};
 		A8E0C0B22A23636100C8696E /* Application */ = {
@@ -380,9 +396,9 @@
 			files = (
 				CEE3E7862A17A93300BC1464 /* LaunchScreen.storyboard in Resources */,
 				CEE3E7832A17A93300BC1464 /* Assets.xcassets in Resources */,
-				A82EC6732A26380A00DABF26 /* Pretendard-Regular.ttf in Resources */,
-				A82EC6712A26380A00DABF26 /* Pretendard-Medium.ttf in Resources */,
-				A82EC6752A26380A00DABF26 /* Pretendard-Bold.ttf in Resources */,
+				A88B18C42A26EEDA0027B5FD /* Pretendard-Regular.ttf in Resources */,
+				A88B18C02A26EEC50027B5FD /* Pretendard-Bold.ttf in Resources */,
+				A88B18C22A26EECF0027B5FD /* Pretendard-Medium.ttf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Waving-iOS/DesignSystem/Color/Colors.swift
+++ b/Waving-iOS/DesignSystem/Color/Colors.swift
@@ -1,0 +1,33 @@
+//
+//  Colors.swift
+//  Waving-iOS
+//
+//  Created by Joy on 2023/05/30.
+//
+
+import Foundation
+import UIKit
+
+extension UIColor {
+    // MARK: - Main Color
+    /// #F8D749
+    static var main090: UIColor { return #colorLiteral(red: 0.9802921414, green: 0.8646150231, blue: 0.3539540768, alpha: 1) }
+    /// #FFFAD9
+    static var main010: UIColor { return #colorLiteral(red: 1, green: 0.9815712571, blue: 0.8793492317, alpha: 1) }
+    
+    // MARK: - Text Colors
+    /// #222222
+    static var text090: UIColor { return #colorLiteral(red: 0.1777858436, green: 0.1777858436, blue: 0.1777858436, alpha: 1) }
+    /// #666666
+    static var text050: UIColor { return #colorLiteral(red: 0.4, green: 0.4, blue: 0.4, alpha: 1) }
+    /// #9e9e9e
+    static var text030: UIColor { return #colorLiteral(red: 0.6196078431, green: 0.6196078431, blue: 0.6196078431, alpha: 1) }
+    /// #FFFFFF
+    static var text010: UIColor { return #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1) }
+    /// #2473FC
+    static var notice050: UIColor { return #colorLiteral(red: 0.1411764706, green: 0.4509803922, blue: 0.9882352941, alpha: 1) }
+    /// #EB1E1E
+    static var caution050: UIColor { return #colorLiteral(red: 0.9215686275, green: 0.1176470588, blue: 0.1176470588, alpha: 1) }
+    /// #222222 (50%)
+    static var dim050: UIColor { return #colorLiteral(red: 0.1333333333, green: 0.1333333333, blue: 0.1333333333, alpha: 0.5) }
+}

--- a/Waving-iOS/DesignSystem/Font/FontManager.swift
+++ b/Waving-iOS/DesignSystem/Font/FontManager.swift
@@ -1,0 +1,24 @@
+//
+//  FontManager.swift
+//  Waving-iOS
+//
+//  Created by Joy on 2023/05/30.
+//
+
+import Foundation
+import UIKit
+
+struct FontManager{
+    static let shared = FontManager()
+    
+    enum Pretendard: String {
+        case bold = "Bold"
+        case medium = "Medium"
+        case regular = "Regular"
+    }
+    
+    func pretendard(_ type: Pretendard, _ size: CGFloat) -> UIFont {
+        let name = "Pretendared-" + type.rawValue
+        return UIFont(name: name, size: size) ?? UIFont.systemFont(ofSize: size)
+    }
+}


### PR DESCRIPTION
# 🛠️ 작업 내용

#13 
- 디자인 시스템에 따른 폰트 추가: Pretendard
- 디자인 시스템에 따른 컬러 추가 

# 👀 사용 예시
## 1. 폰트
싱글톤 객체를 활용한 FontManager를 통해 구현했습니다.<br/>
프리텐다드 글씨체 종류에 따라 **1번째 argument**에는 bold, medium, regular 로 구분되며, **2번째 argument**에는 폰트 사이즈가 위치하게 됩니다.

``` swift
    $0.font = FontManager.shared.pretendard(.bold, 18)
```

## 2. 디자인 시스템에 따른 컬러 구분
1. 피그마 디자인 시스템에 따라 main과 text컬러를 추가했습니다.
<img width="1097" alt="스크린샷 2023-06-03 오전 5 55 05" src="https://github.com/bside-tinkerbell/Waving-iOS/assets/84610593/aedde35b-e445-414b-bdca-1482fe73dca6">

2. 관련 코드 
<img width="394" alt="스크린샷 2023-06-03 오전 5 51 33" src="https://github.com/bside-tinkerbell/Waving-iOS/assets/84610593/1f80b223-bb23-4701-8677-da1770a2aae8">

3. 사용 방법
```swift
$0.textColor = .main010
```
