### PR TITLE
[Refactor] 공용 네비게이션 바 수정

### DIFF
--- a/Waving-iOS/Presentation/Etc/ViewController.swift
+++ b/Waving-iOS/Presentation/Etc/ViewController.swift
@@ -11,10 +11,10 @@ import Then
 
 class ViewController: UIViewController, SnapKitInterface {
     
-    let navigationView = NavigationView(frame: .zero, type: .button_twoicon).then {
-        $0.titleLabel.text = "프로필"
-        $0.favoriteButton.setImage(UIImage(named: "icn_favorites_on"), for:.normal)
-    }
+//    let navigationView = NavigationView(frame: .zero, type: .button_twoicon).then {
+//        $0.titleLabel.text = "프로필"
+//        $0.favoriteButton.setImage(UIImage(named: "icn_favorites_on"), for:.normal)
+//    }
     
     private let loginButton = UIButton().then {
         $0.setTitle("로그인 버튼", for: .normal)
@@ -31,16 +31,16 @@ class ViewController: UIViewController, SnapKitInterface {
     }
     
     func addComponents() {
-        [navigationView, loginButton].forEach { view.addSubview($0) }
+        [loginButton].forEach { view.addSubview($0) }
     
     }
     
     func setConstraints() {
-        navigationView.snp.makeConstraints {
-            $0.left.right.equalTo(view.safeAreaLayoutGuide)
-            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
-            $0.height.equalTo(50)
-        }
+//        navigationView.snp.makeConstraints {
+//            $0.left.right.equalTo(view.safeAreaLayoutGuide)
+//            $0.top.equalTo(view.safeAreaLayoutGuide.snp.top)
+//            $0.height.equalTo(50)
+//        }
 
         loginButton.snp.makeConstraints {
             $0.centerX.centerY.equalToSuperview()


### PR DESCRIPTION
# ⚒️ 작업 내용
#32 
- 공용 네비게이션 바를 수정했습니다.
- 이전 작업에서는 네비게이션 바 4종류를 enum의 type에 따라 나누어 구분했었는데, 이것보다 재은님께서 WVButton 하신 것처럼 하는 게 확장성 측면에서도 더 좋을 거 같아 refactoring했습니당! 😊

# 👀 사용 예시
```swift
import UIKit

final class FriendsViewController: UIViewController {
    
    private lazy var navigationViewModel: NavigationModel = .init(backButtonImage: UIImage(named: "icn_back"), title: "회원가입")
    
    private lazy var navigationView: NavigationView = {
        let view = NavigationView()
        view.setup(model: navigationViewModel)
    
        return view
    }()

    override func viewDidLoad() {
        super.viewDidLoad()

        view.backgroundColor = .systemBackground
        view.addSubview(navigationView)
        navigationView.snp.makeConstraints {
            $0.top.left.right.equalTo(view.safeAreaLayoutGuide)
            $0.height.equalTo(50)
        }
    }
}

```