### PR TITLE
[Feat] 네트워킹 기능 설계(URLSession, Combine 사용)

### DIFF
--- a/Waving-iOS.xcodeproj/project.pbxproj
+++ b/Waving-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A81DF39A2A8CFB8D00BE3EEF /* GetFriendsDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81DF3992A8CFB8D00BE3EEF /* GetFriendsDTO.swift */; };
 		A8253D542A46A77A00AE8101 /* FriendsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8253D532A46A77A00AE8101 /* FriendsViewModel.swift */; };
 		A8253D5A2A46E1AB00AE8101 /* FriendsIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8253D592A46E1AB00AE8101 /* FriendsIntroView.swift */; };
 		A8253D5C2A46E1C000AE8101 /* FriendsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8253D5B2A46E1C000AE8101 /* FriendsListView.swift */; };
@@ -145,6 +146,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A81DF3992A8CFB8D00BE3EEF /* GetFriendsDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFriendsDTO.swift; sourceTree = "<group>"; };
 		A8253D532A46A77A00AE8101 /* FriendsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsViewModel.swift; sourceTree = "<group>"; };
 		A8253D592A46E1AB00AE8101 /* FriendsIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsIntroView.swift; sourceTree = "<group>"; };
 		A8253D5B2A46E1C000AE8101 /* FriendsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsListView.swift; sourceTree = "<group>"; };
@@ -478,6 +480,7 @@
 			children = (
 				A836B19A2A6CE96100D9F02F /* SaveFriendsDTO.swift */,
 				A8C874372A6EBB4C0057EEEA /* SaveFriendsResponseDTO.swift */,
+				A81DF3992A8CFB8D00BE3EEF /* GetFriendsDTO.swift */,
 			);
 			path = Friends;
 			sourceTree = "<group>";
@@ -1142,6 +1145,7 @@
 				A8BF47572A84B26F00FCDD7C /* SampleAPI.swift in Sources */,
 				A87144E22A8022FF00E5FCAD /* TopProfileView.swift in Sources */,
 				CEB518262A65410D009B88BB /* NoticeCellModel.swift in Sources */,
+				A81DF39A2A8CFB8D00BE3EEF /* GetFriendsDTO.swift in Sources */,
 				CED83A9F2A2B86F40031AFF0 /* SignupViewController.swift in Sources */,
 				CED9EAB42A3C3C5700BA8737 /* SignupStepTermOfUseView.swift in Sources */,
 				A89871B02A5D8069008F0FAA /* FriendsContactViewModel.swift in Sources */,

--- a/Waving-iOS.xcodeproj/project.pbxproj
+++ b/Waving-iOS.xcodeproj/project.pbxproj
@@ -9,6 +9,10 @@
 /* Begin PBXBuildFile section */
 		A81DF39A2A8CFB8D00BE3EEF /* GetFriendsDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81DF3992A8CFB8D00BE3EEF /* GetFriendsDTO.swift */; };
 		A81DF39F2A8D0A4B00BE3EEF /* ModifyFriendProfileDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81DF39E2A8D0A4B00BE3EEF /* ModifyFriendProfileDTO.swift */; };
+		A81DF3A22A8D363B00BE3EEF /* FriendsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81DF3A12A8D363B00BE3EEF /* FriendsDataSource.swift */; };
+		A81DF3A42A8D364500BE3EEF /* FriendsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81DF3A32A8D364500BE3EEF /* FriendsRepository.swift */; };
+		A81DF3A62A8D387700BE3EEF /* UserEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81DF3A52A8D387700BE3EEF /* UserEndPoint.swift */; };
+		A81DF3A82A8D38A300BE3EEF /* FriendsEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81DF3A72A8D38A300BE3EEF /* FriendsEndPoint.swift */; };
 		A8253D542A46A77A00AE8101 /* FriendsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8253D532A46A77A00AE8101 /* FriendsViewModel.swift */; };
 		A8253D5A2A46E1AB00AE8101 /* FriendsIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8253D592A46E1AB00AE8101 /* FriendsIntroView.swift */; };
 		A8253D5C2A46E1C000AE8101 /* FriendsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8253D5B2A46E1C000AE8101 /* FriendsListView.swift */; };
@@ -149,6 +153,10 @@
 /* Begin PBXFileReference section */
 		A81DF3992A8CFB8D00BE3EEF /* GetFriendsDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFriendsDTO.swift; sourceTree = "<group>"; };
 		A81DF39E2A8D0A4B00BE3EEF /* ModifyFriendProfileDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyFriendProfileDTO.swift; sourceTree = "<group>"; };
+		A81DF3A12A8D363B00BE3EEF /* FriendsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsDataSource.swift; sourceTree = "<group>"; };
+		A81DF3A32A8D364500BE3EEF /* FriendsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsRepository.swift; sourceTree = "<group>"; };
+		A81DF3A52A8D387700BE3EEF /* UserEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEndPoint.swift; sourceTree = "<group>"; };
+		A81DF3A72A8D38A300BE3EEF /* FriendsEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsEndPoint.swift; sourceTree = "<group>"; };
 		A8253D532A46A77A00AE8101 /* FriendsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsViewModel.swift; sourceTree = "<group>"; };
 		A8253D592A46E1AB00AE8101 /* FriendsIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsIntroView.swift; sourceTree = "<group>"; };
 		A8253D5B2A46E1C000AE8101 /* FriendsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsListView.swift; sourceTree = "<group>"; };
@@ -304,6 +312,16 @@
 				A81DF39E2A8D0A4B00BE3EEF /* ModifyFriendProfileDTO.swift */,
 			);
 			path = FriendProfile;
+			sourceTree = "<group>";
+		};
+		A81DF3A02A8D362500BE3EEF /* Friends */ = {
+			isa = PBXGroup;
+			children = (
+				A81DF3A12A8D363B00BE3EEF /* FriendsDataSource.swift */,
+				A81DF3A32A8D364500BE3EEF /* FriendsRepository.swift */,
+				A81DF3A72A8D38A300BE3EEF /* FriendsEndPoint.swift */,
+			);
+			path = Friends;
 			sourceTree = "<group>";
 		};
 		A8253D4B2A46A5CB00AE8101 /* Friends */ = {
@@ -479,8 +497,8 @@
 		A87144FA2A8157F500E5FCAD /* DTO */ = {
 			isa = PBXGroup;
 			children = (
-				A81DF39B2A8D08FA00BE3EEF /* FriendProfile */,
 				A8BF46DA2A832CE900FCDD7C /* Sample */,
+				A81DF39B2A8D08FA00BE3EEF /* FriendProfile */,
 				A87144FC2A815B7200E5FCAD /* Friends */,
 			);
 			path = DTO;
@@ -569,6 +587,7 @@
 			isa = PBXGroup;
 			children = (
 				A8BF47A72A85323900FCDD7C /* Sample */,
+				A81DF3A02A8D362500BE3EEF /* Friends */,
 				A8BF47A32A850D9A00FCDD7C /* APIEndpoint.swift */,
 				A8BF47A52A850DB100FCDD7C /* APIClient.swift */,
 			);
@@ -580,6 +599,7 @@
 			children = (
 				A8BF47A82A85325200FCDD7C /* SampleDataSource.swift */,
 				A8BF47AF2A853AE300FCDD7C /* SampleRepository.swift */,
+				A81DF3A52A8D387700BE3EEF /* UserEndPoint.swift */,
 			);
 			path = Sample;
 			sourceTree = "<group>";
@@ -1146,6 +1166,7 @@
 				A8A45CBE2A409856001F02C7 /* ErrorMessage.swift in Sources */,
 				CE9BBCDF2A2AFA3B0036E335 /* WVButton.swift in Sources */,
 				CEE3E77C2A17A93200BC1464 /* SceneDelegate.swift in Sources */,
+				A81DF3A22A8D363B00BE3EEF /* FriendsDataSource.swift in Sources */,
 				A8C792902A4E5F5C0032FDFC /* BasePaddingLabel.swift in Sources */,
 				A8C874382A6EBB4C0057EEEA /* SaveFriendsResponseDTO.swift in Sources */,
 				A8BF46E12A83305F00FCDD7C /* SampleViewController.swift in Sources */,
@@ -1185,8 +1206,10 @@
 				CEC778A72A74F42600C42A01 /* GreetingSuggestionCellModel.swift in Sources */,
 				A8F4DD422A4660560045C179 /* CALayer+.swift in Sources */,
 				CEDC679B2A6CA7EA009D37AE /* GreetingCategoryCellModel.swift in Sources */,
+				A81DF3A42A8D364500BE3EEF /* FriendsRepository.swift in Sources */,
 				A82EC67A2A263D1800DABF26 /* FontManager.swift in Sources */,
 				CEBC400F2A486D09001A5934 /* TabViewModel.swift in Sources */,
+				A81DF3A82A8D38A300BE3EEF /* FriendsEndPoint.swift in Sources */,
 				CE8316DC2A318449007D3327 /* SignupStepViewModel.swift in Sources */,
 				A89871AA2A5B9576008F0FAA /* FriendsContactViewController.swift in Sources */,
 				A8F4DD442A4660640045C179 /* UITabBar+.swift in Sources */,
@@ -1202,6 +1225,7 @@
 				A8253D5A2A46E1AB00AE8101 /* FriendsIntroView.swift in Sources */,
 				A836B19D2A6CFB2700D9F02F /* ContactEntity.swift in Sources */,
 				A836B19B2A6CE96100D9F02F /* SaveFriendsDTO.swift in Sources */,
+				A81DF3A62A8D387700BE3EEF /* UserEndPoint.swift in Sources */,
 				CEBC40082A486B9D001A5934 /* TopTabBarViewController.swift in Sources */,
 				CE67983C2A31F2500078F43C /* SignupTextFieldContainer.swift in Sources */,
 				A89871B22A5DB865008F0FAA /* FriendsContactCollectionViewCell.swift in Sources */,

--- a/Waving-iOS.xcodeproj/project.pbxproj
+++ b/Waving-iOS.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		A83861692A8D9D6700E8B609 /* FriendsEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83861682A8D9D6700E8B609 /* FriendsEndpoint.swift */; };
 		A838616E2A8DAE5D00E8B609 /* FriendsDataUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A838616D2A8DAE5D00E8B609 /* FriendsDataUseCase.swift */; };
 		A83861702A8DD07C00E8B609 /* GetFriendsEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A838616F2A8DD07C00E8B609 /* GetFriendsEntity.swift */; };
+		A83861722A8DD2DF00E8B609 /* FriendsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83861712A8DD2DF00E8B609 /* FriendsDataSource.swift */; };
+		A83861742A8DD35A00E8B609 /* FriendsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83861732A8DD35A00E8B609 /* FriendsRepository.swift */; };
 		A87144BE2A7E39EE00E5FCAD /* CycleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A87144BD2A7E39EE00E5FCAD /* CycleViewController.swift */; };
 		A87144DC2A8022AA00E5FCAD /* FriendProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A87144DB2A8022AA00E5FCAD /* FriendProfileViewController.swift */; };
 		A87144DE2A8022B600E5FCAD /* FriendProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A87144DD2A8022B600E5FCAD /* FriendProfileViewModel.swift */; };
@@ -168,6 +170,8 @@
 		A83861682A8D9D6700E8B609 /* FriendsEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsEndpoint.swift; sourceTree = "<group>"; };
 		A838616D2A8DAE5D00E8B609 /* FriendsDataUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsDataUseCase.swift; sourceTree = "<group>"; };
 		A838616F2A8DD07C00E8B609 /* GetFriendsEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFriendsEntity.swift; sourceTree = "<group>"; };
+		A83861712A8DD2DF00E8B609 /* FriendsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsDataSource.swift; sourceTree = "<group>"; };
+		A83861732A8DD35A00E8B609 /* FriendsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsRepository.swift; sourceTree = "<group>"; };
 		A87144BD2A7E39EE00E5FCAD /* CycleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleViewController.swift; sourceTree = "<group>"; };
 		A87144DB2A8022AA00E5FCAD /* FriendProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendProfileViewController.swift; sourceTree = "<group>"; };
 		A87144DD2A8022B600E5FCAD /* FriendProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendProfileViewModel.swift; sourceTree = "<group>"; };
@@ -413,6 +417,8 @@
 			isa = PBXGroup;
 			children = (
 				A83861682A8D9D6700E8B609 /* FriendsEndpoint.swift */,
+				A83861712A8DD2DF00E8B609 /* FriendsDataSource.swift */,
+				A83861732A8DD35A00E8B609 /* FriendsRepository.swift */,
 			);
 			path = Friends;
 			sourceTree = "<group>";
@@ -1152,12 +1158,14 @@
 				A8A45CC02A409B75001F02C7 /* NavigationView.swift in Sources */,
 				CEC6CF942A618F7F00175391 /* GreetingCategoryCollectionViewCell.swift in Sources */,
 				CEE16BFE2A3484DF003EC97E /* SignupStepBirthdateView.swift in Sources */,
+				A83861742A8DD35A00E8B609 /* FriendsRepository.swift in Sources */,
 				CEC6CF7F2A61147500175391 /* GreetingModel.swift in Sources */,
 				A8BF47A92A85325200FCDD7C /* SampleDataSource.swift in Sources */,
 				CEBC40152A486F55001A5934 /* TabViewCollectionViewCell.swift in Sources */,
 				A8BF47592A84B27500FCDD7C /* SampleTarget.swift in Sources */,
 				A87144EB2A809E7200E5FCAD /* FavoriteView.swift in Sources */,
 				A8BF46E52A8331E500FCDD7C /* SampleEntity.swift in Sources */,
+				A83861722A8DD2DF00E8B609 /* FriendsDataSource.swift in Sources */,
 				CEDC67882A6C95B1009D37AE /* HomeCollectionHeaderViewModel.swift in Sources */,
 				A8BF47B02A853AE300FCDD7C /* SampleRepository.swift in Sources */,
 				CE9BBCD32A297F7D0036E335 /* IntroViewController.swift in Sources */,

--- a/Waving-iOS.xcodeproj/project.pbxproj
+++ b/Waving-iOS.xcodeproj/project.pbxproj
@@ -9,10 +9,7 @@
 /* Begin PBXBuildFile section */
 		A81DF39A2A8CFB8D00BE3EEF /* GetFriendsDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81DF3992A8CFB8D00BE3EEF /* GetFriendsDTO.swift */; };
 		A81DF39F2A8D0A4B00BE3EEF /* ModifyFriendProfileDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81DF39E2A8D0A4B00BE3EEF /* ModifyFriendProfileDTO.swift */; };
-		A81DF3A22A8D363B00BE3EEF /* FriendsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81DF3A12A8D363B00BE3EEF /* FriendsDataSource.swift */; };
-		A81DF3A42A8D364500BE3EEF /* FriendsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81DF3A32A8D364500BE3EEF /* FriendsRepository.swift */; };
 		A81DF3A62A8D387700BE3EEF /* UserEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81DF3A52A8D387700BE3EEF /* UserEndPoint.swift */; };
-		A81DF3A82A8D38A300BE3EEF /* FriendsEndPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81DF3A72A8D38A300BE3EEF /* FriendsEndPoint.swift */; };
 		A8253D542A46A77A00AE8101 /* FriendsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8253D532A46A77A00AE8101 /* FriendsViewModel.swift */; };
 		A8253D5A2A46E1AB00AE8101 /* FriendsIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8253D592A46E1AB00AE8101 /* FriendsIntroView.swift */; };
 		A8253D5C2A46E1C000AE8101 /* FriendsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8253D5B2A46E1C000AE8101 /* FriendsListView.swift */; };
@@ -22,6 +19,9 @@
 		A836B1882A6A04DD00D9F02F /* FriendsAddView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A836B1872A6A04DD00D9F02F /* FriendsAddView.swift */; };
 		A836B19B2A6CE96100D9F02F /* SaveFriendsDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = A836B19A2A6CE96100D9F02F /* SaveFriendsDTO.swift */; };
 		A836B19D2A6CFB2700D9F02F /* ContactEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A836B19C2A6CFB2700D9F02F /* ContactEntity.swift */; };
+		A83861662A8D994D00E8B609 /* Encodable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83861652A8D994D00E8B609 /* Encodable+.swift */; };
+		A83861692A8D9D6700E8B609 /* FriendsEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83861682A8D9D6700E8B609 /* FriendsEndpoint.swift */; };
+		A838616E2A8DAE5D00E8B609 /* FriendsDataUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A838616D2A8DAE5D00E8B609 /* FriendsDataUseCase.swift */; };
 		A87144BE2A7E39EE00E5FCAD /* CycleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A87144BD2A7E39EE00E5FCAD /* CycleViewController.swift */; };
 		A87144DC2A8022AA00E5FCAD /* FriendProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A87144DB2A8022AA00E5FCAD /* FriendProfileViewController.swift */; };
 		A87144DE2A8022B600E5FCAD /* FriendProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A87144DD2A8022B600E5FCAD /* FriendProfileViewModel.swift */; };
@@ -153,10 +153,7 @@
 /* Begin PBXFileReference section */
 		A81DF3992A8CFB8D00BE3EEF /* GetFriendsDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFriendsDTO.swift; sourceTree = "<group>"; };
 		A81DF39E2A8D0A4B00BE3EEF /* ModifyFriendProfileDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyFriendProfileDTO.swift; sourceTree = "<group>"; };
-		A81DF3A12A8D363B00BE3EEF /* FriendsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsDataSource.swift; sourceTree = "<group>"; };
-		A81DF3A32A8D364500BE3EEF /* FriendsRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsRepository.swift; sourceTree = "<group>"; };
 		A81DF3A52A8D387700BE3EEF /* UserEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEndPoint.swift; sourceTree = "<group>"; };
-		A81DF3A72A8D38A300BE3EEF /* FriendsEndPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsEndPoint.swift; sourceTree = "<group>"; };
 		A8253D532A46A77A00AE8101 /* FriendsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsViewModel.swift; sourceTree = "<group>"; };
 		A8253D592A46E1AB00AE8101 /* FriendsIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsIntroView.swift; sourceTree = "<group>"; };
 		A8253D5B2A46E1C000AE8101 /* FriendsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsListView.swift; sourceTree = "<group>"; };
@@ -166,6 +163,9 @@
 		A836B1872A6A04DD00D9F02F /* FriendsAddView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsAddView.swift; sourceTree = "<group>"; };
 		A836B19A2A6CE96100D9F02F /* SaveFriendsDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SaveFriendsDTO.swift; sourceTree = "<group>"; };
 		A836B19C2A6CFB2700D9F02F /* ContactEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactEntity.swift; sourceTree = "<group>"; };
+		A83861652A8D994D00E8B609 /* Encodable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+.swift"; sourceTree = "<group>"; };
+		A83861682A8D9D6700E8B609 /* FriendsEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsEndpoint.swift; sourceTree = "<group>"; };
+		A838616D2A8DAE5D00E8B609 /* FriendsDataUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsDataUseCase.swift; sourceTree = "<group>"; };
 		A87144BD2A7E39EE00E5FCAD /* CycleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleViewController.swift; sourceTree = "<group>"; };
 		A87144DB2A8022AA00E5FCAD /* FriendProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendProfileViewController.swift; sourceTree = "<group>"; };
 		A87144DD2A8022B600E5FCAD /* FriendProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendProfileViewModel.swift; sourceTree = "<group>"; };
@@ -314,16 +314,6 @@
 			path = FriendProfile;
 			sourceTree = "<group>";
 		};
-		A81DF3A02A8D362500BE3EEF /* Friends */ = {
-			isa = PBXGroup;
-			children = (
-				A81DF3A12A8D363B00BE3EEF /* FriendsDataSource.swift */,
-				A81DF3A32A8D364500BE3EEF /* FriendsRepository.swift */,
-				A81DF3A72A8D38A300BE3EEF /* FriendsEndPoint.swift */,
-			);
-			path = Friends;
-			sourceTree = "<group>";
-		};
 		A8253D4B2A46A5CB00AE8101 /* Friends */ = {
 			isa = PBXGroup;
 			children = (
@@ -416,6 +406,22 @@
 			path = Friends;
 			sourceTree = "<group>";
 		};
+		A83861672A8D9D5800E8B609 /* Friends */ = {
+			isa = PBXGroup;
+			children = (
+				A83861682A8D9D6700E8B609 /* FriendsEndpoint.swift */,
+			);
+			path = Friends;
+			sourceTree = "<group>";
+		};
+		A838616C2A8DAE4700E8B609 /* Friends */ = {
+			isa = PBXGroup;
+			children = (
+				A838616D2A8DAE5D00E8B609 /* FriendsDataUseCase.swift */,
+			);
+			path = Friends;
+			sourceTree = "<group>";
+		};
 		A87144D72A80226D00E5FCAD /* FriendProfile */ = {
 			isa = PBXGroup;
 			children = (
@@ -472,6 +478,7 @@
 		A87144F12A8141C700E5FCAD /* UseCase */ = {
 			isa = PBXGroup;
 			children = (
+				A838616C2A8DAE4700E8B609 /* Friends */,
 				A8BF47AA2A8534F600FCDD7C /* Sample */,
 			);
 			path = UseCase;
@@ -586,10 +593,11 @@
 		A8BF47A22A850D7400FCDD7C /* API */ = {
 			isa = PBXGroup;
 			children = (
+				A83861672A8D9D5800E8B609 /* Friends */,
 				A8BF47A72A85323900FCDD7C /* Sample */,
-				A81DF3A02A8D362500BE3EEF /* Friends */,
 				A8BF47A32A850D9A00FCDD7C /* APIEndpoint.swift */,
 				A8BF47A52A850DB100FCDD7C /* APIClient.swift */,
+				A83861652A8D994D00E8B609 /* Encodable+.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -1124,6 +1132,7 @@
 				CE66AF012A63C69A001B7C96 /* GreetingSuggestionCollectionViewCell.swift in Sources */,
 				CEA7BCC42A7FAAAF0000727C /* HomeViewModel.swift in Sources */,
 				CE0412AE2A2359CF00C790F3 /* MainTabBarViewModel.swift in Sources */,
+				A83861692A8D9D6700E8B609 /* FriendsEndpoint.swift in Sources */,
 				A8C7928C2A4E4E400032FDFC /* Toast.swift in Sources */,
 				CEDC67862A6C94BC009D37AE /* HomeCollectionReusableView.swift in Sources */,
 				A82EC6632A2634B500DABF26 /* Colors.swift in Sources */,
@@ -1150,6 +1159,7 @@
 				CE9BBCD32A297F7D0036E335 /* IntroViewController.swift in Sources */,
 				CEE3E77A2A17A93200BC1464 /* AppDelegate.swift in Sources */,
 				A8BF47AC2A85351500FCDD7C /* FetchSampleDataUseCase.swift in Sources */,
+				A838616E2A8DAE5D00E8B609 /* FriendsDataUseCase.swift in Sources */,
 				CEB5181D2A653FA2009B88BB /* NoticeViewController.swift in Sources */,
 				A8E0C10F2A23685C00C8696E /* SnapKitInterface.swift in Sources */,
 				CEF31EE62A5FC74E00534D44 /* GreetingAPI.swift in Sources */,
@@ -1166,7 +1176,6 @@
 				A8A45CBE2A409856001F02C7 /* ErrorMessage.swift in Sources */,
 				CE9BBCDF2A2AFA3B0036E335 /* WVButton.swift in Sources */,
 				CEE3E77C2A17A93200BC1464 /* SceneDelegate.swift in Sources */,
-				A81DF3A22A8D363B00BE3EEF /* FriendsDataSource.swift in Sources */,
 				A8C792902A4E5F5C0032FDFC /* BasePaddingLabel.swift in Sources */,
 				A8C874382A6EBB4C0057EEEA /* SaveFriendsResponseDTO.swift in Sources */,
 				A8BF46E12A83305F00FCDD7C /* SampleViewController.swift in Sources */,
@@ -1198,6 +1207,7 @@
 				A87144BE2A7E39EE00E5FCAD /* CycleViewController.swift in Sources */,
 				A87144EF2A809FCE00E5FCAD /* ContactListView.swift in Sources */,
 				CED83AA12A2B87050031AFF0 /* LoginViewController.swift in Sources */,
+				A83861662A8D994D00E8B609 /* Encodable+.swift in Sources */,
 				CEC778CD2A768B6000C42A01 /* UIWindow+.swift in Sources */,
 				CE9BBCE12A2B0F270036E335 /* UIColor+.swift in Sources */,
 				A87144E42A80230A00E5FCAD /* BottomProfileView.swift in Sources */,
@@ -1206,10 +1216,8 @@
 				CEC778A72A74F42600C42A01 /* GreetingSuggestionCellModel.swift in Sources */,
 				A8F4DD422A4660560045C179 /* CALayer+.swift in Sources */,
 				CEDC679B2A6CA7EA009D37AE /* GreetingCategoryCellModel.swift in Sources */,
-				A81DF3A42A8D364500BE3EEF /* FriendsRepository.swift in Sources */,
 				A82EC67A2A263D1800DABF26 /* FontManager.swift in Sources */,
 				CEBC400F2A486D09001A5934 /* TabViewModel.swift in Sources */,
-				A81DF3A82A8D38A300BE3EEF /* FriendsEndPoint.swift in Sources */,
 				CE8316DC2A318449007D3327 /* SignupStepViewModel.swift in Sources */,
 				A89871AA2A5B9576008F0FAA /* FriendsContactViewController.swift in Sources */,
 				A8F4DD442A4660640045C179 /* UITabBar+.swift in Sources */,

--- a/Waving-iOS.xcodeproj/project.pbxproj
+++ b/Waving-iOS.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		A81DF39A2A8CFB8D00BE3EEF /* GetFriendsDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81DF3992A8CFB8D00BE3EEF /* GetFriendsDTO.swift */; };
+		A81DF39F2A8D0A4B00BE3EEF /* ModifyFriendProfileDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = A81DF39E2A8D0A4B00BE3EEF /* ModifyFriendProfileDTO.swift */; };
 		A8253D542A46A77A00AE8101 /* FriendsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8253D532A46A77A00AE8101 /* FriendsViewModel.swift */; };
 		A8253D5A2A46E1AB00AE8101 /* FriendsIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8253D592A46E1AB00AE8101 /* FriendsIntroView.swift */; };
 		A8253D5C2A46E1C000AE8101 /* FriendsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8253D5B2A46E1C000AE8101 /* FriendsListView.swift */; };
@@ -147,6 +148,7 @@
 
 /* Begin PBXFileReference section */
 		A81DF3992A8CFB8D00BE3EEF /* GetFriendsDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFriendsDTO.swift; sourceTree = "<group>"; };
+		A81DF39E2A8D0A4B00BE3EEF /* ModifyFriendProfileDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyFriendProfileDTO.swift; sourceTree = "<group>"; };
 		A8253D532A46A77A00AE8101 /* FriendsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsViewModel.swift; sourceTree = "<group>"; };
 		A8253D592A46E1AB00AE8101 /* FriendsIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsIntroView.swift; sourceTree = "<group>"; };
 		A8253D5B2A46E1C000AE8101 /* FriendsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsListView.swift; sourceTree = "<group>"; };
@@ -296,6 +298,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		A81DF39B2A8D08FA00BE3EEF /* FriendProfile */ = {
+			isa = PBXGroup;
+			children = (
+				A81DF39E2A8D0A4B00BE3EEF /* ModifyFriendProfileDTO.swift */,
+			);
+			path = FriendProfile;
+			sourceTree = "<group>";
+		};
 		A8253D4B2A46A5CB00AE8101 /* Friends */ = {
 			isa = PBXGroup;
 			children = (
@@ -469,6 +479,7 @@
 		A87144FA2A8157F500E5FCAD /* DTO */ = {
 			isa = PBXGroup;
 			children = (
+				A81DF39B2A8D08FA00BE3EEF /* FriendProfile */,
 				A8BF46DA2A832CE900FCDD7C /* Sample */,
 				A87144FC2A815B7200E5FCAD /* Friends */,
 			);
@@ -1146,6 +1157,7 @@
 				A87144E22A8022FF00E5FCAD /* TopProfileView.swift in Sources */,
 				CEB518262A65410D009B88BB /* NoticeCellModel.swift in Sources */,
 				A81DF39A2A8CFB8D00BE3EEF /* GetFriendsDTO.swift in Sources */,
+				A81DF39F2A8D0A4B00BE3EEF /* ModifyFriendProfileDTO.swift in Sources */,
 				CED83A9F2A2B86F40031AFF0 /* SignupViewController.swift in Sources */,
 				CED9EAB42A3C3C5700BA8737 /* SignupStepTermOfUseView.swift in Sources */,
 				A89871B02A5D8069008F0FAA /* FriendsContactViewModel.swift in Sources */,

--- a/Waving-iOS.xcodeproj/project.pbxproj
+++ b/Waving-iOS.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		A83861662A8D994D00E8B609 /* Encodable+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83861652A8D994D00E8B609 /* Encodable+.swift */; };
 		A83861692A8D9D6700E8B609 /* FriendsEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83861682A8D9D6700E8B609 /* FriendsEndpoint.swift */; };
 		A838616E2A8DAE5D00E8B609 /* FriendsDataUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A838616D2A8DAE5D00E8B609 /* FriendsDataUseCase.swift */; };
+		A83861702A8DD07C00E8B609 /* GetFriendsEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A838616F2A8DD07C00E8B609 /* GetFriendsEntity.swift */; };
 		A87144BE2A7E39EE00E5FCAD /* CycleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A87144BD2A7E39EE00E5FCAD /* CycleViewController.swift */; };
 		A87144DC2A8022AA00E5FCAD /* FriendProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A87144DB2A8022AA00E5FCAD /* FriendProfileViewController.swift */; };
 		A87144DE2A8022B600E5FCAD /* FriendProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A87144DD2A8022B600E5FCAD /* FriendProfileViewModel.swift */; };
@@ -166,6 +167,7 @@
 		A83861652A8D994D00E8B609 /* Encodable+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+.swift"; sourceTree = "<group>"; };
 		A83861682A8D9D6700E8B609 /* FriendsEndpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsEndpoint.swift; sourceTree = "<group>"; };
 		A838616D2A8DAE5D00E8B609 /* FriendsDataUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendsDataUseCase.swift; sourceTree = "<group>"; };
+		A838616F2A8DD07C00E8B609 /* GetFriendsEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetFriendsEntity.swift; sourceTree = "<group>"; };
 		A87144BD2A7E39EE00E5FCAD /* CycleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleViewController.swift; sourceTree = "<group>"; };
 		A87144DB2A8022AA00E5FCAD /* FriendProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendProfileViewController.swift; sourceTree = "<group>"; };
 		A87144DD2A8022B600E5FCAD /* FriendProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FriendProfileViewModel.swift; sourceTree = "<group>"; };
@@ -402,6 +404,7 @@
 			isa = PBXGroup;
 			children = (
 				A836B19C2A6CFB2700D9F02F /* ContactEntity.swift */,
+				A838616F2A8DD07C00E8B609 /* GetFriendsEntity.swift */,
 			);
 			path = Friends;
 			sourceTree = "<group>";
@@ -1135,6 +1138,7 @@
 				A83861692A8D9D6700E8B609 /* FriendsEndpoint.swift in Sources */,
 				A8C7928C2A4E4E400032FDFC /* Toast.swift in Sources */,
 				CEDC67862A6C94BC009D37AE /* HomeCollectionReusableView.swift in Sources */,
+				A83861702A8DD07C00E8B609 /* GetFriendsEntity.swift in Sources */,
 				A82EC6632A2634B500DABF26 /* Colors.swift in Sources */,
 				CEC778CB2A768A8100C42A01 /* NSAttributedString+.swift in Sources */,
 				CEE16C002A34867C003EC97E /* SignupStepPhoneNumberView.swift in Sources */,

--- a/Waving-iOS/Data/API/APIClient.swift
+++ b/Waving-iOS/Data/API/APIClient.swift
@@ -21,7 +21,6 @@ class URLSessionAPIClient<EndpointType: APIEndpoint>: APIClient {
         guard let httpBody = try? JSONSerialization.data(withJSONObject: params, options: []) else {
             return nil
         }
-
         return httpBody
     }
     

--- a/Waving-iOS/Data/API/APIClient.swift
+++ b/Waving-iOS/Data/API/APIClient.swift
@@ -9,18 +9,28 @@ import Foundation
 import Combine
 import UIKit
 
-protocol APIClient {
+protocol APIClient { 
     associatedtype EndpointType: APIEndpoint
-    func request<T: Decodable>(_ endpoint: EndpointType) -> AnyPublisher<T, Error>
+    func request<T: Codable>(_ endpoint: EndpointType) -> AnyPublisher<T, Error>
 }
 
 class URLSessionAPIClient<EndpointType: APIEndpoint>: APIClient {
-    func request<T: Decodable>(_ endpoint: EndpointType) -> AnyPublisher<T, Error> {
+    
+    private func requestBodyFrom(params: [String: Any]?) -> Data? {
+        guard let params = params else { return nil }
+        guard let httpBody = try? JSONSerialization.data(withJSONObject: params, options: []) else {
+            return nil
+        }
+
+        return httpBody
+    }
+    
+    func request<T: Codable>(_ endpoint: EndpointType) -> AnyPublisher<T, Error> {
         let url = endpoint.baseURL.appendingPathComponent(endpoint.path)
         var request = URLRequest(url: url)
         request.httpMethod = endpoint.method.rawValue
-        
         endpoint.headers?.forEach { request.addValue($0.value, forHTTPHeaderField: $0.key) }
+        request.httpBody = requestBodyFrom(params: endpoint.parameters)
         
         // 데이터 통신
         return URLSession.shared.dataTaskPublisher(for: request)

--- a/Waving-iOS/Data/API/APIEndpoint.swift
+++ b/Waving-iOS/Data/API/APIEndpoint.swift
@@ -28,38 +28,3 @@ enum APIError: Error {
     case invalidData
 }
 
-enum UserEndpoint: APIEndpoint {
-    case getUsers
-    
-    var baseURL: URL {
-        return URL(string: Server.baseURL)!
-    }
-    
-    var path: String {
-        switch self {
-        case .getUsers:
-            return "/users"
-        }
-    }
-    
-    var method: HTTPMethod {
-        switch self {
-        case .getUsers:
-            return .get
-        }
-    }
-    
-    var headers: [String: String]? {
-        switch self {
-        case .getUsers:
-           return ["Content-type": "application/json"]
-        }
-    }
-    
-    var parameters: [String: Any]? {
-        switch self {
-        case .getUsers:
-            return nil
-        }
-    }
-}

--- a/Waving-iOS/Data/API/Encodable+.swift
+++ b/Waving-iOS/Data/API/Encodable+.swift
@@ -1,0 +1,18 @@
+//
+//  Encodable+.swift
+//  Waving-iOS
+//
+//  Created by Joy on 2023/08/17.
+//
+
+import Foundation
+
+extension Encodable {
+    var asDictionary: [String: Any] {
+        guard let data = try? JSONEncoder().encode(self) else { return [:] }
+        guard let dictionary = try? JSONSerialization.jsonObject(with: data, options: .allowFragments) as? [String: Any] else {
+            return [:]
+        }
+        return dictionary
+    }
+}

--- a/Waving-iOS/Data/API/Friends/FriendsDataSource.swift
+++ b/Waving-iOS/Data/API/Friends/FriendsDataSource.swift
@@ -1,0 +1,26 @@
+//
+//  FriendsDataSource.swift
+//  Waving-iOS
+//
+//  Created by Joy on 2023/08/17.
+//
+
+import Foundation
+import Combine
+
+protocol FriendsDataSourceInterface {
+    func save() -> AnyPublisher<SaveFriendsResponseDTO, Error>
+    func fetch() -> AnyPublisher<GetFriendsDTO, Error>
+}
+
+final class FriendsDataSource: FriendsDataSourceInterface {
+    let apiClient = URLSessionAPIClient<FriendsEndpoint>()
+    
+    func save() -> AnyPublisher<SaveFriendsResponseDTO, Error> {
+        return apiClient.request(.saveFriends)
+    }
+    
+    func fetch() -> AnyPublisher<GetFriendsDTO, Error> {
+        return apiClient.request(.getFriends)
+    }
+}

--- a/Waving-iOS/Data/API/Friends/FriendsEndpoint.swift
+++ b/Waving-iOS/Data/API/Friends/FriendsEndpoint.swift
@@ -1,0 +1,53 @@
+//
+//  FriendsEndpoint.swift
+//  Waving-iOS
+//
+//  Created by Joy on 2023/08/17.
+//
+
+import Foundation
+
+enum FriendsEndpoint: APIEndpoint {
+    case saveFriends
+    case getFriends
+    
+    var baseURL: URL {
+        return URL(string: Server.baseURL)!
+    }
+    
+    var path: String {
+        switch self {
+        case .saveFriends:
+            return "/v1/friends/register"
+        case .getFriends:
+            return "/v1/friends/list/16" //TODO: 임의적(맨 뒤 user_id 들어가야 함)
+        }
+    }
+    
+    var method: HTTPMethod {
+        switch self {
+        case .saveFriends:
+            return .post
+        case .getFriends:
+            return .get
+        }
+    }
+    
+    var headers: [String: String]? {
+        switch self {
+        case .saveFriends, .getFriends:
+           return ["Content-type": "application/json"]
+        }
+    }
+    
+    var parameters: [String: Any]? {
+        switch self {
+        case .saveFriends:
+            let saveFriendsDTO = SaveFriendsDTO(userId: 16, contactId: 22, profileList: [PersonModel(name: "가나다", cellPhone: "010-1234-5678", contactCycle: 2)]) //TODO: API 작동 실험용
+
+            return saveFriendsDTO.asDictionary
+        case .getFriends:
+            return nil
+        }
+    }
+}

--- a/Waving-iOS/Data/API/Friends/FriendsRepository.swift
+++ b/Waving-iOS/Data/API/Friends/FriendsRepository.swift
@@ -1,0 +1,38 @@
+//
+//  FriendsRepository.swift
+//  Waving-iOS
+//
+//  Created by Joy on 2023/08/17.
+//
+
+import Foundation
+import Combine
+
+protocol FriendsRepositoryInterface {
+    func fetchGetFriendsEntity() -> AnyPublisher<[GetFriendsEntity], Error>
+    func saveFriends() -> AnyPublisher<SaveFriendsResponseDTO, Error>
+}
+
+final class FriendsRepository: FriendsRepositoryInterface {
+    
+    private let dataSouce: FriendsDataSourceInterface
+    
+    public init(dataSouce: FriendsDataSourceInterface) {
+        self.dataSouce = dataSouce
+    }
+    
+    func fetchGetFriendsEntity() -> AnyPublisher<[GetFriendsEntity], Error> {
+        return dataSouce.fetch()
+            .map { getFriendsDTO in
+                var getFriendsEntities = [GetFriendsEntity]()
+                for profileList in getFriendsDTO.result.profileList { getFriendsEntities.append(profileList.toDomain())
+                }
+                return getFriendsEntities
+            }
+            .eraseToAnyPublisher()
+    }
+    
+    func saveFriends() -> AnyPublisher<SaveFriendsResponseDTO, Error> {
+        return dataSouce.save()
+    }
+}

--- a/Waving-iOS/Data/API/Sample/UserEndPoint.swift
+++ b/Waving-iOS/Data/API/Sample/UserEndPoint.swift
@@ -1,0 +1,44 @@
+//
+//  SampleEndPoint.swift
+//  Waving-iOS
+//
+//  Created by Joy on 2023/08/17.
+//
+
+import Foundation
+
+enum UserEndpoint: APIEndpoint {
+    case getUsers
+    
+    var baseURL: URL {
+        return URL(string: Server.baseURL)!
+    }
+    
+    var path: String {
+        switch self {
+        case .getUsers:
+            return "/users"
+        }
+    }
+    
+    var method: HTTPMethod {
+        switch self {
+        case .getUsers:
+            return .get
+        }
+    }
+    
+    var headers: [String: String]? {
+        switch self {
+        case .getUsers:
+           return ["Content-type": "application/json"]
+        }
+    }
+    
+    var parameters: [String: Any]? {
+        switch self {
+        case .getUsers:
+            return nil
+        }
+    }
+}

--- a/Waving-iOS/Data/DTO/FriendProfile/ModifyFriendProfileDTO.swift
+++ b/Waving-iOS/Data/DTO/FriendProfile/ModifyFriendProfileDTO.swift
@@ -1,0 +1,33 @@
+//
+//  ModifyFriendProfileDTO.swift
+//  Waving-iOS
+//
+//  Created by Joy on 2023/08/16.
+//
+
+import Foundation
+
+struct ModifyFriendProfileDTO: Codable {
+    var name: String
+    var cellPhone: String
+    var birthday: String
+    var contactCycle: Int
+    var recentContactDate: String
+    
+    enum CodingKeys: String, CodingKey {
+        case name
+        case cellPhone
+        case birthday
+        case contactCycle = "contact_cycle"
+        case recentContactDate = "recent_contact_date"
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.cellPhone = try container.decode(String.self, forKey: .cellPhone)
+        self.birthday = try container.decode(String.self, forKey: .birthday)
+        self.contactCycle = try container.decode(Int.self, forKey: .contactCycle)
+        self.recentContactDate = try container.decode(String.self, forKey: .recentContactDate)
+    }
+}

--- a/Waving-iOS/Data/DTO/Friends/GetFriendsDTO.swift
+++ b/Waving-iOS/Data/DTO/Friends/GetFriendsDTO.swift
@@ -1,0 +1,75 @@
+//
+//  GetFriendsDTO.swift
+//  Waving-iOS
+//
+//  Created by Joy on 2023/08/16.
+//
+
+import Foundation
+
+struct GetFriendsDTO: Codable {
+    var code: Int
+    var result: GetFriendsResultDTO
+}
+
+struct GetFriendsResultDTO: Codable {
+    var message: String
+    var profileList: [GetFriendsProfileDTO]
+    var favoriteProfileList: [GetFriendsProfileDTO]
+    var profileCount: Int
+    var favoriteCount: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case message
+        case profileList = "profile_list"
+        case favoriteProfileList = "favorite_profile_list"
+        case profileCount = "profile_cnt"
+        case favoriteCount = "favorite_cnt"
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.message = try container.decode(String.self, forKey: .message)
+        self.profileList = try container.decode([GetFriendsProfileDTO].self, forKey: .profileList)
+        self.favoriteProfileList = try container.decode([GetFriendsProfileDTO].self, forKey: .favoriteProfileList)
+        self.profileCount = try container.decode(Int.self, forKey: .profileCount)
+        self.favoriteCount = try container.decode(Int.self, forKey: .favoriteCount)
+    }
+}
+
+struct GetFriendsProfileDTO: Codable {
+    var contactId: Int
+    var friendProfileId: Int
+    var isFavorite: Int
+    var name: String
+    var birthday: String
+    var contactCycle: Int
+    var cellPhone: String
+    var recentContactDate: String
+    
+    enum CodingKeys: String, CodingKey {
+        case contactId = "contact_id"
+        case friendProfileId = "friend_profile_id"
+        case isFavorite = "is_favorite"
+        case name
+        case birthday
+        case contactCycle = "contact_cycle"
+        case cellPhone
+        case recentContactDate = "recent_contact_date"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.contactId = try container.decode(Int.self, forKey: .contactId)
+        self.friendProfileId = try container.decode(Int.self, forKey: .friendProfileId)
+        self.isFavorite = try container.decode(Int.self, forKey: .isFavorite)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.birthday = try container.decode(String.self, forKey: .birthday)
+        self.contactCycle = try container.decode(Int.self, forKey: .contactCycle)
+        self.cellPhone = try container.decode(String.self, forKey: .cellPhone)
+        self.recentContactDate = try container.decode(String.self, forKey: .recentContactDate)
+    }
+}
+
+
+

--- a/Waving-iOS/Data/DTO/Friends/GetFriendsDTO.swift
+++ b/Waving-iOS/Data/DTO/Friends/GetFriendsDTO.swift
@@ -54,7 +54,7 @@ struct GetFriendsProfileDTO: Codable {
         case name
         case birthday
         case contactCycle = "contact_cycle"
-        case cellPhone
+        case cellPhone = "cellphone"
         case recentContactDate = "recent_contact_date"
     }
 
@@ -64,10 +64,10 @@ struct GetFriendsProfileDTO: Codable {
         self.friendProfileId = try container.decode(Int.self, forKey: .friendProfileId)
         self.isFavorite = try container.decode(Int.self, forKey: .isFavorite)
         self.name = try container.decode(String.self, forKey: .name)
-        self.birthday = try container.decode(String.self, forKey: .birthday)
+        self.birthday = (try? container.decode(String.self, forKey: .birthday)) ?? ""
         self.contactCycle = try container.decode(Int.self, forKey: .contactCycle)
         self.cellPhone = try container.decode(String.self, forKey: .cellPhone)
-        self.recentContactDate = try container.decode(String.self, forKey: .recentContactDate)
+        self.recentContactDate = (try? container.decode(String.self, forKey: .recentContactDate)) ?? ""
     }
 }
 

--- a/Waving-iOS/Data/DTO/Friends/GetFriendsDTO.swift
+++ b/Waving-iOS/Data/DTO/Friends/GetFriendsDTO.swift
@@ -71,5 +71,9 @@ struct GetFriendsProfileDTO: Codable {
     }
 }
 
-
+extension GetFriendsProfileDTO {
+    func toDomain() -> GetFriendsEntity {
+        return .init(name: name, friendProfileId: friendProfileId)
+    }
+}
 

--- a/Waving-iOS/Data/DTO/Friends/SaveFriendsDTO.swift
+++ b/Waving-iOS/Data/DTO/Friends/SaveFriendsDTO.swift
@@ -9,6 +9,7 @@ import Foundation
 
 var personList = [PersonModel]()
 
+// TODO: 1-Depth로 병합해도 좋을 듯
 struct SaveFriendsDTO: Codable {
     var userId: Int
     var contactId: Int // 지인 목록 API GET해 왔을 때 주어지는 값
@@ -37,26 +38,26 @@ struct SaveFriendsDTO: Codable {
 
 struct PersonModel: Codable {
     var name: String
-    var phoneNumber: String
+    var cellPhone: String
     var contactCycle: Int
 
-    
+
     enum CodingKeys: String, CodingKey {
         case name
-        case phoneNumber = "phone_number"
+        case cellPhone = "cellphone"
         case contactCycle = "contact_cycle"
     }
-    
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.name = try container.decode(String.self, forKey: .name)
-        self.phoneNumber = try container.decode(String.self, forKey: .phoneNumber)
+        self.cellPhone = try container.decode(String.self, forKey: .cellPhone)
         self.contactCycle = try container.decode(Int.self, forKey: .contactCycle)
     }
-    
-    init(name: String, phoneNumber: String, contactCycle: Int) {
+
+    init(name: String, cellPhone: String, contactCycle: Int) {
         self.name = name
-        self.phoneNumber = phoneNumber
+        self.cellPhone = cellPhone
         self.contactCycle = contactCycle
     }
 }

--- a/Waving-iOS/Data/DTO/Friends/SaveFriendsDTO.swift
+++ b/Waving-iOS/Data/DTO/Friends/SaveFriendsDTO.swift
@@ -11,7 +11,7 @@ var personList = [PersonModel]()
 
 struct SaveFriendsDTO: Codable {
     var userId: Int
-    var contactId: Int
+    var contactId: Int // 지인 목록 API GET해 왔을 때 주어지는 값
     var profileList: [PersonModel]
     
     enum CodingKeys: String, CodingKey {

--- a/Waving-iOS/Data/DTO/Friends/SaveFriendsResponseDTO.swift
+++ b/Waving-iOS/Data/DTO/Friends/SaveFriendsResponseDTO.swift
@@ -35,7 +35,7 @@ struct ProfileListModel: Codable {
     var name: String
     var birthday: String
     var contactCycle: Int
-    var phoneNumber: String
+    var cellPhone: String
     var recentContactDate: String
     
     enum CodingKeys: String, CodingKey {
@@ -45,7 +45,7 @@ struct ProfileListModel: Codable {
         case name
         case birthday
         case contactCycle = "contact_cycle"
-        case phoneNumber = "phone_number"
+        case cellPhone = "cellphone"
         case recentContactDate = "recent_contact_date"
     }
     
@@ -57,7 +57,7 @@ struct ProfileListModel: Codable {
         self.name = try container.decode(String.self, forKey: .name)
         self.birthday = (try? container.decode(String.self, forKey: .birthday)) ?? ""
         self.contactCycle = (try? container.decode(Int.self, forKey: .contactCycle)) ?? 0
-        self.phoneNumber = try container.decode(String.self, forKey: .phoneNumber)
+        self.cellPhone = try container.decode(String.self, forKey: .cellPhone)
         self.recentContactDate = (try? container.decode(String.self, forKey: .recentContactDate)) ?? ""
     }
 }

--- a/Waving-iOS/Data/Network/URLString.swift
+++ b/Waving-iOS/Data/Network/URLString.swift
@@ -8,6 +8,6 @@
 import Foundation
 
 struct Server {
-    //static let baseURL = "http://118.67.130.127:8080" //우리 서버
-    static let baseURL = "https://reqres.in/api" // API 테스트용
+    static let baseURL = "http://118.67.130.127:8080" //우리 서버
+    //static let baseURL = "https://reqres.in/api" // API 테스트용
 }

--- a/Waving-iOS/Domain/Entity/Friends/GetFriendsEntity.swift
+++ b/Waving-iOS/Domain/Entity/Friends/GetFriendsEntity.swift
@@ -1,0 +1,13 @@
+//
+//  GetFriendsEntity.swift
+//  Waving-iOS
+//
+//  Created by Joy on 2023/08/17.
+//
+
+import Foundation
+
+struct GetFriendsEntity {
+    let name: String
+    let friendProfileId: String
+}

--- a/Waving-iOS/Domain/Entity/Friends/GetFriendsEntity.swift
+++ b/Waving-iOS/Domain/Entity/Friends/GetFriendsEntity.swift
@@ -10,4 +10,9 @@ import Foundation
 struct GetFriendsEntity {
     let name: String
     let friendProfileId: Int
+    
+    public init(name: String, friendProfileId: Int) {
+        self.name = name
+        self.friendProfileId = friendProfileId
+    }
 }

--- a/Waving-iOS/Domain/Entity/Friends/GetFriendsEntity.swift
+++ b/Waving-iOS/Domain/Entity/Friends/GetFriendsEntity.swift
@@ -9,5 +9,5 @@ import Foundation
 
 struct GetFriendsEntity {
     let name: String
-    let friendProfileId: String
+    let friendProfileId: Int
 }

--- a/Waving-iOS/Domain/UseCase/Friends/FriendsDataUseCase.swift
+++ b/Waving-iOS/Domain/UseCase/Friends/FriendsDataUseCase.swift
@@ -1,0 +1,26 @@
+//
+//  FriendsDataUseCase.swift
+//  Waving-iOS
+//
+//  Created by Joy on 2023/08/17.
+//
+
+import Foundation
+import Combine
+
+protocol FriendsDataUseCaseInterface {
+    func save() -> AnyPublisher<SaveFriendsResponseDTO, Error>
+    func fetch() -> AnyPublisher<GetFriendsDTO, Error>
+}
+
+final class FriendsDataUseCase: FriendsDataUseCaseInterface {
+    let apiClient = URLSessionAPIClient<FriendsEndpoint>()
+    
+    func save() -> AnyPublisher<SaveFriendsResponseDTO, Error> {
+        return apiClient.request(.saveFriends)
+    }
+    
+    func fetch() -> AnyPublisher<GetFriendsDTO, Error> {
+        return apiClient.request(.getFriends)
+    }
+}

--- a/Waving-iOS/Domain/UseCase/Friends/FriendsDataUseCase.swift
+++ b/Waving-iOS/Domain/UseCase/Friends/FriendsDataUseCase.swift
@@ -9,18 +9,18 @@ import Foundation
 import Combine
 
 protocol FriendsDataUseCaseInterface {
-    func save() -> AnyPublisher<SaveFriendsResponseDTO, Error>
-    func fetch() -> AnyPublisher<GetFriendsDTO, Error>
+    func saveFriends() -> AnyPublisher<SaveFriendsResponseDTO, Error>
+    func fetchFriendsEntity() -> AnyPublisher<[GetFriendsEntity], Error>
 }
 
 final class FriendsDataUseCase: FriendsDataUseCaseInterface {
-    let apiClient = URLSessionAPIClient<FriendsEndpoint>()
+    private let repository = FriendsRepository(dataSouce: FriendsDataSource())
     
-    func save() -> AnyPublisher<SaveFriendsResponseDTO, Error> {
-        return apiClient.request(.saveFriends)
+    func saveFriends() -> AnyPublisher<SaveFriendsResponseDTO, Error> {
+        return repository.saveFriends()
     }
     
-    func fetch() -> AnyPublisher<GetFriendsDTO, Error> {
-        return apiClient.request(.getFriends)
+    func fetchFriendsEntity() -> AnyPublisher<[GetFriendsEntity], Error> {
+        return repository.fetchGetFriendsEntity()
     }
 }

--- a/Waving-iOS/Presentation/Friends/ViewModel/FriendsViewModel.swift
+++ b/Waving-iOS/Presentation/Friends/ViewModel/FriendsViewModel.swift
@@ -74,7 +74,7 @@ class FriendsViewModel: FriendsViewModelRepresentable {
                     let phoneNumber = contact.phoneNumbers.filter { $0.label == CNLabelPhoneNumberMobile }.map { $0.value.stringValue }.joined(separator:"")
                     type = .addFriend
                     myContactList.append(ContactEntity(name: name, phoneNumber: phoneNumber))
-                    personList.append(PersonModel(name: name, phoneNumber: phoneNumber, contactCycle: 4))
+//                    personList.append(PersonModel(name: name, phoneNumber: phoneNumber, contactCycle: 4))
                 })
             } catch {
                 Log.e("연락처를 가져올 수 없습니다 화면으로 이동하기")

--- a/Waving-iOS/Presentation/Sample/SampleViewController.swift
+++ b/Waving-iOS/Presentation/Sample/SampleViewController.swift
@@ -9,7 +9,8 @@ import UIKit
 
 final class SampleViewController: UIViewController {
     
-    var viewModel = SampleViewModel(FetchSampleDataUseCase())
+    //var viewModel = SampleViewModel(FetchSampleDataUseCase())
+    var viewModel = SampleViewModel(FriendsDataUseCase())
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Waving-iOS/Presentation/Sample/SampleViewModel.swift
+++ b/Waving-iOS/Presentation/Sample/SampleViewModel.swift
@@ -41,8 +41,8 @@ final class SampleViewModel {
         }
     
         public func fetchSample() {
-            //useCase.fetch()
-            useCase.save()
+            useCase.saveFriends()
+            //useCase.fetchFriendsEntity()
                 .sink(receiveCompletion: { completion in
                     if case .failure(let err) = completion {
                         Log.e("Retrieving data failed with error \(err)")

--- a/Waving-iOS/Presentation/Sample/SampleViewModel.swift
+++ b/Waving-iOS/Presentation/Sample/SampleViewModel.swift
@@ -8,17 +8,41 @@
 import Foundation
 import Combine
 
+//final class SampleViewModel {
+//
+//        private let useCase: FetchSampleDataUseCase
+//        private var cancellables = Set<AnyCancellable>()
+//
+//        init(_ useCase: FetchSampleDataUseCase) {
+//            self.useCase = useCase
+//        }
+//
+//        public func fetchSample() {
+//            useCase.execute()
+//                .sink(receiveCompletion: { completion in
+//                    if case .failure(let err) = completion {
+//                        Log.e("Retrieving data failed with error \(err)")
+//                    }
+//                }, receiveValue: { data in
+//                    Log.i("Retrieved data of size \(data), response = \(data)")
+//
+//                })
+//                .store(in: &cancellables)
+//        }
+//}
+
 final class SampleViewModel {
     
-        private let useCase: FetchSampleDataUseCase
+        private let useCase: FriendsDataUseCase
         private var cancellables = Set<AnyCancellable>()
     
-        init(_ useCase: FetchSampleDataUseCase) {
+        init(_ useCase: FriendsDataUseCase) {
             self.useCase = useCase
         }
     
         public func fetchSample() {
-            useCase.execute()
+            //useCase.fetch()
+            useCase.save()
                 .sink(receiveCompletion: { completion in
                     if case .failure(let err) = completion {
                         Log.e("Retrieving data failed with error \(err)")
@@ -30,3 +54,4 @@ final class SampleViewModel {
                 .store(in: &cancellables)
         }
 }
+


### PR DESCRIPTION
# 🛠️ 작업 내용
### 네트워킹 기능 설계
#51 
- 라이브러리 쓰지 않고도 네트워킹 기능을 구현해 보고 싶어 Combine과 dataTaskPublisher을 사용해 설계해 보았습니다. 
- 관련 파일: APIEndpoint, APIClient, Encodable+

### DTO 추가
- 지인 목록 DTO: GetFriendsDTO
- 지인 프로필 편집 DTO: ModifyFriendProfileDTO

### Entity 추가
- 지인 목록 Entity: GetFriendsEntity ➡️ 지인 리스트 화면에서 사용하기 위해 GetFriendsProfileDTO(GetFriendsDTO안의 하위 depth)를 extension을 통해 GetFriendsEntity로 변환하도록 설계해 보았습니다.

### 클린 아키텍처에 맞게 네트워킹 기능 추가
- API: SaveFriendList(지인 추가)와 GetFriendList(지인 리스트) API를 연동했습니다. 작동하는지 SampleViewModel, SampleViewController을 통해 출력해 보았습니다.
- 관련 파일: FriendsEndpoint, FriendsDataSource, FriendsRepository, FriendsDataUseCase

