### PR TITLE
feat: 회원가입 > 생년월일 validation 로직 수정

### DIFF
--- a/Waving-iOS/Application/SignDataStore.swift
+++ b/Waving-iOS/Application/SignDataStore.swift
@@ -68,17 +68,28 @@ struct BirthdateFormatter {
     
     static let maxLength: Int = 8   // hyphen 미포함 (예. 19990101)
     static let hyphen = "-"
+    static let birthdateRegex = #"^\d{4}-\d{2}-\d{2}$"#
     
     static func format(text: String) -> String {
-        guard text.count >= 8 else { return text }
+        guard text.count >= 8, !BirthdateFormatter.isValidBirthdate(text) else { return text }
         
-        let result = String(text.prefix(maxLength))
-        
-        Log.d("text length: \(result.count). result: \(text)")
-        let mutableString = NSMutableString(string: result)
+        Log.d("text length: \(text.count). result: \(text)")
+        let mutableString = NSMutableString(string: text)
         mutableString.replaceOccurrences(of: hyphen, with: "", range: .init(location: 0, length: text.count))
         mutableString.insert(hyphen, at: 4)
         mutableString.insert(hyphen, at: 7)
-        return String(mutableString)
+        
+        let result = String(mutableString)
+        if BirthdateFormatter.isValidBirthdate(result) {
+            return result
+        }
+        
+        fatalError("birthdate \(text) is invalid")
+    }
+
+    static func isValidBirthdate(_ input: String) -> Bool {
+        let regex = try! NSRegularExpression(pattern: Self.birthdateRegex)
+        let range = NSRange(location: 0, length: input.utf16.count)
+        return regex.firstMatch(in: input, options: [], range: range) != nil
     }
 }

--- a/Waving-iOS/Data/Network/ResponseData.swift
+++ b/Waving-iOS/Data/Network/ResponseData.swift
@@ -17,6 +17,16 @@ struct ResponseData<Model: Codable> {
                 let model = try JSONDecoder().decode(Model.self, from: response.data)
                 return .success(model)
             } catch {
+                if let keyNotFound = error as? DecodingError {
+                    switch keyNotFound {
+                    case .keyNotFound(let key, _):
+                        print("Key '\(key.stringValue)' not found.")
+                    default:
+                        print("Decoding error: \(error.localizedDescription)")
+                    }
+                } else {
+                    print("Decoding error: \(error.localizedDescription)")
+                }
                 return .failure(error)
             }
         case .failure(let error):

--- a/Waving-iOS/Domain/Entity/SIgn/LoginResponseModel.swift
+++ b/Waving-iOS/Domain/Entity/SIgn/LoginResponseModel.swift
@@ -9,13 +9,24 @@ import Foundation
 
 struct LoginResponseModel: Codable {
     let code: Int
-    let result: TokenModel
+    let result: TokenWrapperModel
+}
+
+struct TokenWrapperModel: Codable {
+    let token: TokenModel
 }
 
 struct TokenModel: Codable {
     let id: Int
     let accessToken: String
     let refreshToken: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case accessToken = "access_token"
+        case refreshToken = "refresh_token"
+    }
+    
 }
 
 /*

--- a/Waving-iOS/Presentation/Signup/View/SignupStepBirthdateView.swift
+++ b/Waving-iOS/Presentation/Signup/View/SignupStepBirthdateView.swift
@@ -17,13 +17,11 @@ final class SignupStepBirthdateView: UIView {
     private var cancellables = [AnyCancellable]()
     
     private var isValidTextfieldValues: Bool {
-        let result = isValidBirthdate
-        Log.d("result: \(result)")
-        return result
+        isValidBirthdate
     }
     
     private var isValidBirthdate: Bool {
-        !birthdateText.isEmpty && birthdateText.count > 0 && birthdateText.count < 9
+        !birthdateText.isEmpty && BirthdateFormatter.isValidBirthdate(birthdateText)
     }
     
     override init(frame: CGRect) {
@@ -67,7 +65,6 @@ final class SignupStepBirthdateView: UIView {
         switch textField.type {
         case .birthdate:
             birthdateText = text
-            viewModel?.updateBirthdate(text)
         default:
             Log.d("default")
         }
@@ -79,6 +76,11 @@ final class SignupStepBirthdateView: UIView {
 extension SignupStepBirthdateView: SignupStepViewRepresentable {
     func setup(with viewModel: SignupStepViewModelRepresentable) {
         self.viewModel = viewModel
+        
+        self.viewModel?.nextButtonAction = { [weak self] in
+            guard let self else { return }
+            self.viewModel?.updateBirthdate(self.birthdateText)
+        }
     }
 }
 

--- a/Waving-iOS/Presentation/Signup/ViewModel/LoginViewModel.swift
+++ b/Waving-iOS/Presentation/Signup/ViewModel/LoginViewModel.swift
@@ -10,28 +10,55 @@ import Foundation
 
 class LoginViewModel {
     
+    private var cancellables: Set<AnyCancellable> = []
+    
+    let emailPublisher = PassthroughSubject<String, Never>()
+    let passwordPublisher = PassthroughSubject<String, Never>()
+    
     var route: AnyPublisher<Void, Never> {
         self.sendRoute.eraseToAnyPublisher()
     }
     
     var sendRoute: PassthroughSubject<Void, Never> = .init()
     
+    init() {
+        bind()
+    }
+    
+    private func bind() {
+        // Combine debounce and receive on the main thread to store data with a 1-second delay
+        emailPublisher
+            .debounce(for: .seconds(1), scheduler: DispatchQueue.main)
+            .sink { [weak self] text in
+                guard let self else { return }
+                updateEmail(text)
+            }
+            .store(in: &cancellables)
+        
+        passwordPublisher
+            .debounce(for: .seconds(1), scheduler: DispatchQueue.main)
+            .sink { [weak self] text in
+                guard let self else { return }
+                updatePassword(text)
+            }
+            .store(in: &cancellables)
+    }
+    
     func login() {
         guard let email = SignDataStore.shared.email,
               let password = SignDataStore.shared.password else { return }
-//        sendRoute.send()
         
         let loginRequestModel = LoginRequestModel(email: email, password: password)
         SignAPI.login(model: loginRequestModel) { succeed, failed in
-            if failed != nil {
-                Log.d("login failed")
+            if let failed {
+                Log.d("login failed: \(failed.localizedDescription)")
                 return
             }
             
             guard let succeed else { return }
-            let tokenModel = succeed.result
+            let tokenModel = succeed.result.token
             Log.d("login succeeded: \(succeed.result)")
-            Log.d("user_id: \(tokenModel.id),access_token: \(tokenModel.accessToken), refresh_token: \(tokenModel.refreshToken)")
+            Log.d("user_id: \(tokenModel.id), access_token: \(tokenModel.accessToken), refresh_token: \(tokenModel.refreshToken)")
             LoginDataStore.shared.userId = tokenModel.id
             LoginDataStore.shared.accessToken = tokenModel.accessToken
             LoginDataStore.shared.refreshToken = tokenModel.refreshToken

--- a/Waving-iOSTests/Waving_iOSTests.swift
+++ b/Waving-iOSTests/Waving_iOSTests.swift
@@ -32,5 +32,15 @@ final class Waving_iOSTests: XCTestCase {
             // Put the code you want to measure the time of here.
         }
     }
-
+    
+    func testIsValidBirthdate_Valid() {
+        let validBirthdate = "1990-12-31"
+        XCTAssertTrue(BirthdateFormatter.isValidBirthdate(validBirthdate))
+    }
+    
+    func testIsValidBirthdate_Invalid() {
+        let invalidBirthdate = "1990-12-31-Invalid"
+        XCTAssertFalse(BirthdateFormatter.isValidBirthdate(invalidBirthdate))
+    }
+    
 }


### PR DESCRIPTION
**생년월일 입력 로직 수정**
- 생년월일 validation 로직을 수정했습니다.
- 형식에 맞지 않는 생년월일 입력 시에는 '다음' 버튼이 활성화되지 않도록 수정되었습니다.
- 생년월일 validation UnitTest 를 추가했습니다.

**로그인 로직 수정**
- 로그인 정보 입력 시 액션 호출을 매번 하지 않고 0.5 초마다 하도록 수정 했습니다. 
- login token response 모델을 수정했습니다.