### PR TITLE
로그인/회원가입 과정에서 키보드가 내려가지 않는 이슈 수정

### DIFF
--- a/Waving-iOS/Presentation/MainTabBar/ViewController/FriendsViewController.swift
+++ b/Waving-iOS/Presentation/MainTabBar/ViewController/FriendsViewController.swift
@@ -99,15 +99,12 @@ final class FriendsViewController: UIViewController, SnapKitInterface {
             .store(in: &cancellable)
         
         self.viewModel.$type
+            .combineLatest(viewModel.$friendsList)
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] friendtype in
+            .sink { [weak self] friendtype, friendsList in
 
                 if let customView = friendtype?.view() {
-                    self?.viewModel.$friendsList
-                        .sink { [weak self] friendsList in
-                            self?.friendsList = friendsList
-                        }
-                    
+                    self?.friendsList = friendsList
                     self?.innerView = customView
                     guard let viewModel = self?.viewModel else {return}
                     guard let friendsList = self?.friendsList else {return}

--- a/Waving-iOS/Presentation/MainTabBar/ViewController/SettingViewController.swift
+++ b/Waving-iOS/Presentation/MainTabBar/ViewController/SettingViewController.swift
@@ -84,7 +84,7 @@ extension SettingViewController {
             cell.contentConfiguration = content
         }
         
-        let cellRegistration = UICollectionView.CellRegistration<UICollectionViewListCell, Item> { [weak self] (cell, indexPath, item) in
+        let cellRegistration = UICollectionView.CellRegistration<UICollectionViewListCell, Item> { (cell, indexPath, item) in
             var content = cell.defaultContentConfiguration()
             content.text = item.title
             cell.contentConfiguration = content

--- a/Waving-iOS/Presentation/Signup/ViewController/LoginViewController.swift
+++ b/Waving-iOS/Presentation/Signup/ViewController/LoginViewController.swift
@@ -40,7 +40,7 @@ final class LoginViewController: UIViewController, SnapKitInterface {
         return textField
     }()
     
-    lazy private var doneButtonModel = WVButtonModel(title: "확인", isEnabled: false, titleColor: .Text.white, backgroundColor: .Button.blackBackground) { [weak self] in
+    lazy private var doneButtonModel = WVButtonModel(title: "로그인", isEnabled: false, titleColor: .Text.white, backgroundColor: .Button.blackBackground) { [weak self] in
         self?.viewModel.login()
     }
     
@@ -70,9 +70,21 @@ final class LoginViewController: UIViewController, SnapKitInterface {
         
         view.backgroundColor = .white
         
+        setupView()
         addComponents()
         setConstraints()
         binding()
+    }
+    
+    private func setupView() {
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        view.addGestureRecognizer(tapGestureRecognizer)
+    }
+    
+    @objc
+    private func dismissKeyboard() {
+        Log.d("dismissKeyboard called")
+        view.endEditing(true)
     }
     
     @objc

--- a/Waving-iOS/Presentation/Signup/ViewController/SignupViewController.swift
+++ b/Waving-iOS/Presentation/Signup/ViewController/SignupViewController.swift
@@ -88,6 +88,8 @@ final class SignupViewController: UIViewController {
         }
     }
     
+    private lazy var tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+    
     init() {
         self.collectionViewCellModels = [.init(type: .emailPassword),
                                          .init(type: .username),
@@ -118,6 +120,8 @@ final class SignupViewController: UIViewController {
     }
     
     private func setupView() {
+        view.addGestureRecognizer(tapGestureRecognizer)
+        
         view.backgroundColor = .white
         
         view.addSubview(buttonContainerView)
@@ -139,7 +143,21 @@ final class SignupViewController: UIViewController {
         collectionView.register(SignupStepCollectionViewCell.self, forCellWithReuseIdentifier: "SignupStepCollectionViewCell")
     }
     
+    @objc
+    private func dismissKeyboard() {
+        view.endEditing(true)
+    }
+    
     private func bind() {
+        currentSignupStepViewModel?.$type
+            .sink { [weak self] type in
+                guard let self else { return }
+                if type == .termsOfUse {
+                    view.removeGestureRecognizer(tapGestureRecognizer)
+                }
+            }
+            .store(in: &cancellables)
+        
         currentSignupStepViewModel?.route
             .sink { [weak self] in
                 self?.navigationController?.popViewController(animated: true)

--- a/Waving-iOS/Presentation/Signup/ViewModel/SignupStepViewModel.swift
+++ b/Waving-iOS/Presentation/Signup/ViewModel/SignupStepViewModel.swift
@@ -30,7 +30,7 @@ enum SignupStepType: Int {
         case .termsOfUse:
             return "이용 약관에\n동의해주세요."
         case .complete:
-            return "회원가입이 완료 됐습니다\n만나서 반가워요 👋🏻"
+            return ""
         }
     }
     

--- a/Waving-iOS/Presentation/Signup/ViewModel/SignupStepViewModel.swift
+++ b/Waving-iOS/Presentation/Signup/ViewModel/SignupStepViewModel.swift
@@ -84,7 +84,7 @@ protocol SignupStepViewModelRepresentable {
 
 class SignupStepViewModel: SignupStepViewModelRepresentable {
     
-    let type: SignupStepType
+    @Published var type: SignupStepType
     let textFieldTypes: [SignupTextFieldType]
     var nextButtonAction: (() -> Void)?
     @Published var title: NSAttributedString?


### PR DESCRIPTION
- 회원가입/로그인 과정에서 키보드가 내려가지 않는 버그 수정
- 회원가입 완료 화면 > 중복된 문구 제거
- etc: warning 제거 (사용하지 않는 self capture 문 제거)
- FriendsViewController warning 제거
    - @JYPjoy 지영님, `viewModel.$type` 의 `sink` 블럭에서 `viewModel.$friendsList` 를 구독하는 대신 `combineLatest` 를 사용해 둘 다 구독하도록 수정했는데 이렇게 해서 warning 을 제거해도 괜찮을지 확인 부탁드릴게요~