### PR TITLE
[FEAT] 둘러보기 기능 추가

### DIFF
--- a/Waving-iOS/Application/SignDataStore.swift
+++ b/Waving-iOS/Application/SignDataStore.swift
@@ -10,7 +10,7 @@ import Foundation
 class LoginDataStore {
     static var shared = LoginDataStore()
     
-    var userId: Int?
+    var userId: Int? = 40
     var accessToken: String?
     var refreshToken: String?
 }

--- a/Waving-iOS/Application/SignDataStore.swift
+++ b/Waving-iOS/Application/SignDataStore.swift
@@ -7,14 +7,14 @@
 
 import Foundation
 
-struct LoginDataStore {
+class LoginDataStore {
     static var shared = LoginDataStore()
     
     var userId: Int?
     var accessToken: String?
     var refreshToken: String?
 }
-struct SignDataStore {
+class SignDataStore {
     static var shared = SignDataStore()
     
     var phoneNumber: String? {

--- a/Waving-iOS/Data/API/Friends/FriendsEndpoint.swift
+++ b/Waving-iOS/Data/API/Friends/FriendsEndpoint.swift
@@ -20,7 +20,7 @@ enum FriendsEndpoint: APIEndpoint {
         case .saveFriends:
             return "/v1/friends/register"
         case .getFriends:
-            let userId = LoginDataStore.shared.userId ?? 0
+            let userId = LoginDataStore.shared.userId ?? 40
            return "/v1/friends/list/" + "\(userId)"
         }
     }

--- a/Waving-iOS/Data/API/Friends/FriendsEndpoint.swift
+++ b/Waving-iOS/Data/API/Friends/FriendsEndpoint.swift
@@ -20,7 +20,7 @@ enum FriendsEndpoint: APIEndpoint {
         case .saveFriends:
             return "/v1/friends/register"
         case .getFriends:
-            let userId = LoginDataStore.shared.userId ?? 36
+            let userId = LoginDataStore.shared.userId ?? 0
            return "/v1/friends/list/" + "\(userId)"
         }
     }

--- a/Waving-iOS/Data/Network/Networkable.swift
+++ b/Waving-iOS/Data/Network/Networkable.swift
@@ -31,6 +31,9 @@ extension Networkable {
     
     static func makeToast() {
         let toast = Toast()
+        lazy var toastModel: ToastModel = .init(title: ToastMessage.networkError.rawValue)
+        toast.setupView(model: toastModel)
+
         if let vc = UIApplication.getMostTopViewController() {
             if let navi = vc.navigationController {
                 navi.view.addSubview(toast)

--- a/Waving-iOS/Data/Network/Networkable.swift
+++ b/Waving-iOS/Data/Network/Networkable.swift
@@ -34,13 +34,10 @@ extension Networkable {
         lazy var toastModel: ToastModel = .init(title: ToastMessage.networkError.rawValue)
         toast.setupView(model: toastModel)
 
-        if let vc = UIApplication.getMostTopViewController() {
-            if let navi = vc.navigationController {
-                navi.view.addSubview(toast)
-                toast.snp.makeConstraints { make in
-                    make.edges.equalToSuperview()
-                }
-            }
-        }
+        guard let vc = UIApplication.getMostTopViewController() else {return}
+        guard let navi = vc.navigationController else {return}
+        
+        navi.view.addSubview(toast)
+        toast.snp.makeConstraints { $0.edges.equalToSuperview() }
     }
 }

--- a/Waving-iOS/Domain/Entity/Friends/GetFriendsProfileEntity.swift
+++ b/Waving-iOS/Domain/Entity/Friends/GetFriendsProfileEntity.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct GetFriendsProfileEntity {
+class GetFriendsProfileEntity {
     static var shared = GetFriendsProfileEntity()
     
     var name: String? {

--- a/Waving-iOS/Presentation/Common/TextField/WVTextField.swift
+++ b/Waving-iOS/Presentation/Common/TextField/WVTextField.swift
@@ -37,6 +37,8 @@ enum SignupTextFieldType {
         switch self {
         case .email:
             return "ex) waving@naver.com"
+        case .passwordConfirm:
+            return "비밀번호를 다시 입력해 주세요."
         case .username:
             return "실명을 입력해주세요.(2~8자)"
         case .birthdate:

--- a/Waving-iOS/Presentation/Common/Toast/Toast.swift
+++ b/Waving-iOS/Presentation/Common/Toast/Toast.swift
@@ -8,12 +8,17 @@
 import Foundation
 import UIKit
 
-class Toast: UIView, SnapKitInterface {
-    
+internal enum ToastMessage: String {
+    case networkError = "네트워크 연결이 끊겼거나 통신 오류가 발생했습니다"
+    case signInMessage = "로그인 후 이용해 주세요"
+}
+
+final class Toast: UIView, SnapKitInterface {
+        
     //MARK: - components
-    private let toastLabel: BasePaddingLabel = {
+    private lazy var toastLabel: BasePaddingLabel = {
         let label = BasePaddingLabel()
-        label.text = "네트워크 연결이 끊겼거나 통신 오류가 발생했습니다"
+        //label.text = "네트워크 연결이 끊겼거나 통신 오류가 발생했습니다"
         label.font = .p_R(16)
         label.textColor = UIColor.white
         label.textAlignment = .center
@@ -22,6 +27,8 @@ class Toast: UIView, SnapKitInterface {
         label.clipsToBounds  =  true
         return label
     }()
+    
+    private var toastModel: ToastModel?
     
     //MARK: - Initializer
     override init(frame: CGRect) {
@@ -50,5 +57,18 @@ class Toast: UIView, SnapKitInterface {
         UIView.animate(withDuration: 3.0, delay: 0.1, options: .curveEaseOut, animations: {self.toastLabel.alpha = 0.0}) { _ in
             self.removeFromSuperview()
         }
+    }
+    
+    public func setupView(model: ToastModel){
+        self.toastModel = model
+        self.toastLabel.text = toastModel?.title
+    }
+}
+
+final class ToastModel {
+    var title: String
+        
+    public init(title: String = "네트워크 연결이 끊겼거나 통신 오류가 발생했습니다"){
+        self.title = title
     }
 }

--- a/Waving-iOS/Presentation/FriendProfile/View/TopProfileView.swift
+++ b/Waving-iOS/Presentation/FriendProfile/View/TopProfileView.swift
@@ -151,6 +151,21 @@ final class TopProfileView: UIView, SnapKitInterface {
     
     @objc
     func didTapCall(){
-        viewModel.call()
+        guard let userId = LoginDataStore.shared.userId else { return }
+        
+        if userId == 40 {
+            let toast = Toast()
+            lazy var toastModel: ToastModel = .init(title: ToastMessage.signInMessage.rawValue)
+            toast.setupView(model: toastModel)
+
+            guard let vc = UIApplication.getMostTopViewController() else {return}
+            guard let navi = vc.navigationController else {return}
+            
+            navi.view.addSubview(toast)
+            toast.snp.makeConstraints { $0.edges.equalToSuperview() }
+        } else {
+            viewModel.call()
+        }
+    
     }
 }


### PR DESCRIPTION
<!--제목 작성 방법 -->
<!--[FEAT/FIX/REFACTOR/STYLE/DOCS/TEST/CHORE] 글 제목 -->

## 🛠️ 작업 내용
<!-- - #이슈번호 -->
- #99 

<br/>

## 👀 소개

<!-- 구현된 내용(스샷 포함), 사용법, 참고 자료, 함께 논의하고 싶은 내용 등을 자유롭게 기재 -->
### 🟩 구현한 내용
**1. 게스트로 둘러보기 선택했을 때 토스트 메시지 기능 추가**
  - userId 기본값을 40으로 잡아 두고, 게스트로 둘러보기 기능을 선택할 경우 40번에 등록된 친구들이 보이도록 설정했습니다.
  - 지인 프로필까지는 보이는데, 연락하기 버튼을 클릭하면, '로그인 후 이용해 주세요' 라는 토스트 메시지가 보이도록 설정했습니다.
  - 지인 프로필 화면

|게스트로 둘러볼 때|로그인 했을 때|
|:--:|:--:|
|<img src = "https://github.com/bside-tinkerbell/Waving-iOS/assets/84610593/5674da48-db76-4574-92c7-027d0d259d25" width = 200>|<img src = "https://github.com/bside-tinkerbell/Waving-iOS/assets/84610593/5b1b14bd-f751-4c64-bfc4-388f8d59043a" width = 200>|
<br/>

**2. 토스트 메시지 확장성 있게 변경**
- 원래는 네트워크 에러 있을 때만 토스트 메시지를 띄웠는데 이제는 통신 오류 외에 게스트로 둘러볼 때도 필요해 ToastMessage를 열거형을 사용해 분리하였고, `ToastModel` 를 생성했습니다.
```swift
internal enum ToastMessage: String {
    case networkError = "네트워크 연결이 끊겼거나 통신 오류가 발생했습니다"
    case signInMessage = "로그인 후 이용해 주세요"
}
```
**3. 리팩터링**
Toast메시지 띄우는 함수에서 이중 if 문을 guard 문을 사용해 `가독성` 있게 수정함 
* 수정 전 코드
```swift
if let vc = UIApplication.getMostTopViewController() {
    if let navi = vc.navigationController {
        navi.view.addSubview(toast)
        toast.snp.makeConstraints { make in
            make.edges.equalToSuperview()
        }
    }
}
```

* 수정 후 코드
```swift
guard let vc = UIApplication.getMostTopViewController() else {return}
guard let navi = vc.navigationController else {return}

navi.view.addSubview(toast)
toast.snp.makeConstraints { $0.edges.equalToSuperview() }
```
<br/>

###  🟩 확인이 필요한 내용
- `LoginDataStore`랑 `SignDataStore`가 싱글톤으로 쓰이는 게 맞는 거 같아 class로 변경했는데 옳은 건지 확인 부탁드려요🧐 

<br/>
