### PR TITLE
[REFACTOR] 가입 시 텍스트 입력 값 validation 로직 리팩토링

### DIFF
--- a/Waving-iOS/Presentation/Signup/View/SignupStepPhoneNumberView.swift
+++ b/Waving-iOS/Presentation/Signup/View/SignupStepPhoneNumberView.swift
@@ -95,20 +95,12 @@ final class SignupStepPhoneNumberView: UIView {
     
     private func isValidText(_ text: String) -> Bool {
         if subStep == .requestAuthCode {
-            return !text.isEmpty && text.count > 0 && text.count <= PhoneNumberFormatter.phoneNumberMaxLength && isValidPhoneNumber(phoneNumber: text)
+            return !text.isEmpty && text.count > 0 && text.count <= PhoneNumberFormatter.phoneNumberMaxLength && text.isValidPhoneNumber
         } else if subStep == .confirmAuthCode {
             return !text.isEmpty && text.count == 5
         }
         
         return false
-    }
-    
-    private func isValidPhoneNumber(phoneNumber: String) -> Bool {
-        let phoneRegex = #"^010-\d{3,4}-\d{4}$"#
-        let phoneTest = NSPredicate(format: "SELF MATCHES %@", phoneRegex)
-        let result = phoneTest.evaluate(with: phoneNumber)
-        Log.d("isValidPhoneNumber: \(result)")
-        return result
     }
     
     private var subStep: SubStep = .requestAuthCode

--- a/Waving-iOS/Presentation/Signup/View/SignupStepUsernameView.swift
+++ b/Waving-iOS/Presentation/Signup/View/SignupStepUsernameView.swift
@@ -24,11 +24,7 @@ final class SignupStepUsernameView: UIView {
     private var isValidUsername: Bool {
         guard !usernameText.isEmpty && usernameText.count > 1 && usernameText.count < 9 else { return false }
         
-        let usernameRegex = "^[a-zA-Z가-힣]{2,}$"
-        let usernameTest = NSPredicate(format: "SELF MATCHES %@", usernameRegex)
-        let result = usernameTest.evaluate(with: usernameText)
-        Log.d("userNameTest: \(result), text: \(usernameText)")
-        return result
+        return usernameText.isValidUsername
     }
     
     override init(frame: CGRect) {

--- a/Waving-iOS/Util/Extension/String+.swift
+++ b/Waving-iOS/Util/Extension/String+.swift
@@ -15,4 +15,14 @@ extension String {
     var isValidPassword: Bool {
         NSPredicate(format: "SELF MATCHES %@", "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*?&])[A-Za-z\\d$@$!%*?&]{8,20}$").evaluate(with: self)
     }
+    
+    /// 010-xxx(or xxxx)-xxxx 형식의 폰 번호인지 체크
+    var isValidPhoneNumber: Bool {
+        NSPredicate(format: "SELF MATCHES %@", #"^010-\d{3,4}-\d{4}$"#).evaluate(with: self)
+    }
+    
+    /// 영문이나 한국어로 두 자 이상인지 체크
+    var isValidUsername: Bool {
+        NSPredicate(format: "SELF MATCHES %@", "^[a-zA-Z가-힣]{2,}$").evaluate(with: self)
+    }
 }


### PR DESCRIPTION
<!--제목 작성 방법 -->
<!--[FEAT/FIX/REFACTOR/STYLE/DOCS/TEST/CHORE] 글 제목 -->

## 🛠️ 작업 내용

- 가입 시 텍스트 입력 값 validation 로직을 String+ 으로 옮김

<br/>

## 👀 소개
- isValidPhoneNumber 의 정규표현식 앞, 뒤에 붙은 해시태그(#) 캐릭터의 의미
    - 스위프트로 정규표현식 쓸 때, 더블 escaping 하는게 불편했는데 스트링 앞 뒤에 해시태그를 붙이면 스트링 literal 이 되어 더블 escaping 할 필요가 없다고 합니다! 👏🏻💡
> ChatGPT: The hashtag character (#) before and after the regex string is used to create a Swift raw string literal. In Swift, a raw string literal is created by placing a # before and after the string. This allows you to include special characters, such as backslashes, without the need for double escaping.

```swift
    var isValidPhoneNumber: Bool {
      NSPredicate(format: "SELF MATCHES %@", #"^010-\d{3,4}-\d{4}$"#).evaluate(with: self)
    }
```

<br/>

