### PR TITLE
[FIX] 회원 가입 및 LoginDataStore 관련 버그 수정

### DIFF
--- a/Waving-iOS/Application/SignDataStore.swift
+++ b/Waving-iOS/Application/SignDataStore.swift
@@ -10,7 +10,7 @@ import Foundation
 class LoginDataStore {
     static var shared = LoginDataStore()
     
-    var userId: Int? = 40
+    var userId: Int? 
     var accessToken: String?
     var refreshToken: String?
 }

--- a/Waving-iOS/Data/API/Friends/FriendsEndpoint.swift
+++ b/Waving-iOS/Data/API/Friends/FriendsEndpoint.swift
@@ -20,7 +20,7 @@ enum FriendsEndpoint: APIEndpoint {
         case .saveFriends:
             return "/v1/friends/register"
         case .getFriends:
-            let userId = LoginDataStore.shared.userId ?? 40
+            let userId = LoginDataStore.shared.userId ?? 68
            return "/v1/friends/list/" + "\(userId)"
         }
     }

--- a/Waving-iOS/Presentation/FriendProfile/View/TopProfileView.swift
+++ b/Waving-iOS/Presentation/FriendProfile/View/TopProfileView.swift
@@ -152,20 +152,6 @@ final class TopProfileView: UIView, SnapKitInterface {
     @objc
     func didTapCall(){
         guard let userId = LoginDataStore.shared.userId else { return }
-        
-        if userId == 40 {
-            let toast = Toast()
-            lazy var toastModel: ToastModel = .init(title: ToastMessage.signInMessage.rawValue)
-            toast.setupView(model: toastModel)
-
-            guard let vc = UIApplication.getMostTopViewController() else {return}
-            guard let navi = vc.navigationController else {return}
-            
-            navi.view.addSubview(toast)
-            toast.snp.makeConstraints { $0.edges.equalToSuperview() }
-        } else {
-            viewModel.call()
-        }
-    
+        viewModel.call()
     }
 }

--- a/Waving-iOS/Presentation/Friends/View/FriendsIntroView.swift
+++ b/Waving-iOS/Presentation/Friends/View/FriendsIntroView.swift
@@ -48,13 +48,13 @@ class FriendsIntroView: UIView, SnapKitInterface {
     
     let friendsAddButton = WVButton()
     private lazy var friendAddButtonViewModel = WVButtonModel(title: "지인 불러오기", titleColor: .Text.white, backgroundColor: .Button.mainBlackButton) { [weak self] in
-        if (SignDataStore.shared.username != nil) {
+        if LoginDataStore.shared.userId != nil {
             self?.viewModel?.addFriends()
         } else {
             let toast = Toast()
             lazy var toastModel: ToastModel = .init(title: ToastMessage.signInMessage.rawValue)
             toast.setupView(model: toastModel)
-
+            
             guard let vc = UIApplication.getMostTopViewController() else {return}
             guard let navi = vc.navigationController else {return}
             

--- a/Waving-iOS/Presentation/Friends/View/FriendsIntroView.swift
+++ b/Waving-iOS/Presentation/Friends/View/FriendsIntroView.swift
@@ -48,7 +48,19 @@ class FriendsIntroView: UIView, SnapKitInterface {
     
     let friendsAddButton = WVButton()
     private lazy var friendAddButtonViewModel = WVButtonModel(title: "지인 불러오기", titleColor: .Text.white, backgroundColor: .Button.mainBlackButton) { [weak self] in
-        self?.viewModel?.addFriends()
+        if (SignDataStore.shared.username != nil) {
+            self?.viewModel?.addFriends()
+        } else {
+            let toast = Toast()
+            lazy var toastModel: ToastModel = .init(title: ToastMessage.signInMessage.rawValue)
+            toast.setupView(model: toastModel)
+
+            guard let vc = UIApplication.getMostTopViewController() else {return}
+            guard let navi = vc.navigationController else {return}
+            
+            navi.view.addSubview(toast)
+            toast.snp.makeConstraints { $0.edges.equalToSuperview() }
+        }
     }
     
     override init(frame: CGRect) {

--- a/Waving-iOS/Presentation/Friends/ViewModel/FriendsViewModel.swift
+++ b/Waving-iOS/Presentation/Friends/ViewModel/FriendsViewModel.swift
@@ -67,7 +67,7 @@ final class FriendsViewModel {
                 case .finished:
                     break
                 case .failure(_):
-                    self.type = .intro//TODO: 서버 끊겼을 때와 진짜 데이터 없을 때의 구분이 필요함
+                    self.type = .intro
                     self.friendsList = []
                 }
             } receiveValue: { getFriendsEntity in

--- a/Waving-iOS/Presentation/Friends/ViewModel/FriendsViewModel.swift
+++ b/Waving-iOS/Presentation/Friends/ViewModel/FriendsViewModel.swift
@@ -106,7 +106,6 @@ extension FriendsViewModel: FriendsViewModelRepresentable {
                     let name = contact.familyName + contact.givenName
                     let phoneNumber = contact.phoneNumbers.filter { $0.label == CNLabelPhoneNumberMobile }.map { $0.value.stringValue }.joined(separator:"")
                     type = .addFriend
-                    let formattedPhoneNumber = PhoneNumberManager.format(phoneNumber)
                     myContactList.append(ContactEntity(name: name, cellPhone: phoneNumber, contactCycle: 2))
                 })
             } catch {

--- a/Waving-iOS/Presentation/MainTabBar/ViewController/FriendsViewController.swift
+++ b/Waving-iOS/Presentation/MainTabBar/ViewController/FriendsViewController.swift
@@ -27,11 +27,9 @@ final class FriendsViewController: UIViewController, SnapKitInterface {
     var friendsList: [GetFriendsEntity] = []
     private var cancellable = Set<AnyCancellable>()
     
-    //TODO: 업로드용
     private lazy var navigationViewModel: NavigationModel = .init(forwaredButtonImage: UIImage(named: ""), title: "나의 지인", didTouchForward: {[weak self] in
         self?.viewModel.didTapForwardButton()
     })
-    
     
     private lazy var navigationView: NavigationView = {
         let view = NavigationView()
@@ -48,7 +46,7 @@ final class FriendsViewController: UIViewController, SnapKitInterface {
         return view
     }()
     
-    private var innerView: UIView?
+    private var innerView: FriendViewRepresentable?
     
     override func viewDidLoad() {
         addComponents()
@@ -59,6 +57,10 @@ final class FriendsViewController: UIViewController, SnapKitInterface {
         super.viewWillAppear(animated)
         fetchData()
         binding()
+    }
+    
+    deinit {
+        innerView?.removeFromSuperview()
     }
     
     func addComponents() {
@@ -109,12 +111,12 @@ final class FriendsViewController: UIViewController, SnapKitInterface {
                     self?.innerView = customView
                     guard let viewModel = self?.viewModel else {return}
                     guard let friendsList = self?.friendsList else {return}
-
-                    customView.setup(with: viewModel, with: friendsList)
-                    
-                    self?.containerView.addSubview(customView)
-                    customView.snp.makeConstraints { make in
-                        make.top.leading.trailing.bottom.equalToSuperview()
+                    guard let innerView = self?.innerView else {return}
+                  
+                    innerView.setup(with: viewModel, with: friendsList)
+                    self?.containerView.addSubview(innerView)
+                    innerView.snp.makeConstraints {
+                        $0.top.leading.trailing.bottom.equalToSuperview()
                     }
                 }
             }

--- a/Waving-iOS/Presentation/MainTabBar/ViewController/SettingViewController.swift
+++ b/Waving-iOS/Presentation/MainTabBar/ViewController/SettingViewController.swift
@@ -143,6 +143,9 @@ final class SettingViewModel {
                 return
             }
             
+            LoginDataStore.shared.userId = nil
+            LoginDataStore.shared.accessToken = ""
+            LoginDataStore.shared.refreshToken = ""
             Log.d("logout succeeded: \(String(describing: succeed))")
             
             NotificationCenter.default.post(name: .userDidLogout, object: nil)
@@ -156,6 +159,10 @@ final class SettingViewModel {
                 Log.d("delete failed: \(String(describing: failed))")
                 return
             }
+            
+            LoginDataStore.shared.userId = nil
+            LoginDataStore.shared.accessToken = ""
+            LoginDataStore.shared.refreshToken = ""
             
             Log.d("delete succeeded: \(String(describing: succeed))")
             

--- a/Waving-iOS/Presentation/Signup/View/SignupStepCompleteView.swift
+++ b/Waving-iOS/Presentation/Signup/View/SignupStepCompleteView.swift
@@ -99,7 +99,7 @@ final class SignupStepCompleteView: UIView, SnapKitInterface {
 extension SignupStepCompleteView: SignupStepViewRepresentable {
     func setup(with viewModel: SignupStepViewModelRepresentable) {
         self.viewModel = viewModel
-        
+        self.viewModel?.isNextButtonEnabled = true
         self.viewModel?.nextButtonAction = {
             NotificationCenter.default.post(name: .userDidLogin, object: nil)
         }

--- a/Waving-iOS/Presentation/Signup/View/SignupStepEmailPasswordView.swift
+++ b/Waving-iOS/Presentation/Signup/View/SignupStepEmailPasswordView.swift
@@ -32,7 +32,8 @@ final class SignupStepEmailPasswordView: UIView {
     }
     
     private var isValidPassword: Bool {
-        passwordText == passwordConfirmText && passwordText.isValidPassword 
+        passwordText == passwordConfirmText
+        && passwordText.isValidPassword
     }
     
     override init(frame: CGRect) {
@@ -95,6 +96,17 @@ final class SignupStepEmailPasswordView: UIView {
             make.trailing.equalToSuperview()
         }
         
+        let textLabel = UILabel()
+        textLabel.text = "영문/숫자/특수문자 2가지 이상 조합하세요.(8~20자)"
+        textLabel.numberOfLines = 0
+        textLabel.textColor = .gray030
+        textLabel.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(textLabel)
+        textLabel.snp.makeConstraints {
+            $0.top.equalTo(passwordConfirmTextFieldContainer.snp.bottom).offset(10)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalToSuperview()
+        }
     }
     
     private func bind() {

--- a/Waving-iOS/Util/Extension/String+.swift
+++ b/Waving-iOS/Util/Extension/String+.swift
@@ -12,7 +12,8 @@ extension String {
         NSPredicate(format: "SELF MATCHES %@", "[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}").evaluate(with: self)
     }
     
+    // 영문/숫자/특수문자 2가지 이상 조합하세요.(8~20자)
     var isValidPassword: Bool {
-        NSPredicate(format: "SELF MATCHES %@", "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[$@$!%*?&])[A-Za-z\\d$@$!%*?&]{8,20}$").evaluate(with: self)
+        NSPredicate(format: "SELF MATCHES %@", "^((?:(?=.*[A-Za-z])(?=.*[$@$!%*?&])|(?:(?=.*[A-Za-z])(?=.*\\d)))|(?:(?=.*[$@$!%*?&])(?=.*\\d))).{8,20}$").evaluate(with: self)
     }
 }


### PR DESCRIPTION
<!--제목 작성 방법 -->
<!--[FEAT/FIX/REFACTOR/STYLE/DOCS/TEST/CHORE] 글 제목 -->

## 🛠️ 작업 내용

<!-- - #이슈번호 -->
- #111
- #113

<br/>

## 👀 소개

<!-- 구현된 내용(스샷 포함), 사용법, 참고 자료, 함께 논의하고 싶은 내용 등을 자유롭게 기재 -->
- 회원가입 마지막 단계에서 다음 버튼 활성화 되지 않는 버그 해결
- 로그인, 회원가입 후 다시 둘러보기 로 돌아왔을 때 예전 회원 목록이 남는 에러 발생 ➡️  로그인 후 관련 정보를 담는 `LoginDataStore`를 초기화함으로써 해결
- 비밀번호 제약 조건 수정: 영문/숫자/특수문자 2가지 이상 으로 수정함